### PR TITLE
Make sure build artifacts exist

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,8 +8,8 @@ general:
     - "jsdoc"
 
 dependencies:
-  override:
-    - npm install
+  post:
+    - npm run build
 
 test:
   post:


### PR DESCRIPTION
Currently, Circle CI can't archive `dist/` since we're never actually building the project :-)