### PR TITLE
Since default is being exported, no need for `{ ... }`

### DIFF
--- a/examples/car-models/src/app.js
+++ b/examples/car-models/src/app.js
@@ -7,7 +7,7 @@ import enigma from 'enigma.js';
 import qixSchema from 'json!../node_modules/enigma.js/schemas/qix/3.1/schema.json';
 import template from 'raw!./app.html';
 import csv from 'raw!../data.csv';
-import { paintBarchart } from './chart';
+import paintBarchart from './chart';
 
 const SCRIPT =
 `LOAD * Inline [


### PR DESCRIPTION
A little typo that was throwing an error where the `app.js` was expecting an exported function rather than using default.