### PR TITLE
Add test:coverage and circleci integration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,7 @@ machine:
 
 general:
   artifacts:
+    - "coverage"
     - "dist"
     - "jsdoc"
 
@@ -12,6 +13,7 @@ dependencies:
     - npm run build
 
 test:
-  post:
+  override:
+    - npm run test:coverage
     - npm run lint
     - npm run jsdoc

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "concurrently \"webpack\" \"npm run test\" \"npm run lint\" \"npm run jsdoc\"",
     "build-watch": "webpack --watch",
     "test": "aw-test-runner ./test/unit ./test/component --compilers js:babel-register",
+    "test:coverage": "aw-test-coverage --dir ./coverage/unit-component -- ./test/unit ./test/component ./src --compilers js:babel-register",
     "test:watch": "aw-test-runner ./test -w --compilers js:babel-register",
     "test:unit": "aw-test-runner ./test/unit --compilers js:babel-register",
     "test:unit:watch": "aw-test-runner ./test/unit -w --compilers js:babel-register",


### PR DESCRIPTION
This enables us to check the coverage for every circleci build (to compare branches etc.).