### PR TITLE
Support connection strings in the qix and rest services

### DIFF
--- a/src/services/qix/index.js
+++ b/src/services/qix/index.js
@@ -78,12 +78,18 @@ export default class Qix {
 
   /**
   * Function used to build an URL.
-  * @param {SessionConfiguration} sessionConfig - The session configuration object.
+  * @param {SessionConfiguration} sessionConfigOrUrl - The session configuration object or the url.
   * @param {String} [appId] The optional app id.
   * @returns {String} Returns the URL.
   */
-  buildUrl(sessionConfig, appId) {
-    const { unsecure, host, port, prefix, subpath, route, identity, reloadURI } = sessionConfig;
+  buildUrl(sessionConfigOrUrl, appId) {
+    if (typeof sessionConfigOrUrl === 'string') {
+      return sessionConfigOrUrl;
+    }
+
+    const {
+      unsecure, host, port, prefix, subpath, route, identity, reloadURI,
+    } = sessionConfigOrUrl;
     let url = '';
 
     url += `${unsecure ? 'ws' : 'wss'}://`;

--- a/src/services/rest/index.js
+++ b/src/services/rest/index.js
@@ -6,6 +6,7 @@ import HttpClient from './http-client';
 *
 * @typedef RestOptions
 * @prop {Object} Promise The ES6-compatible Promise-implementation to use.
+* @prop {String} rootUrl The full root url to connect against.
 * @prop {String} host The host to connect against.
 * @prop {String} [port] The port to connect against, defaults to 80 for HTTP, 443 for HTTPS.
 * @prop {Object} [headers] Additional headers to inject for each request.
@@ -57,8 +58,12 @@ export default class Rest {
       throw new Error('Your environment has no Promise implementation. You must provide a Promise implementation in the config.');
     }
 
-    if (!restOptions.host) {
+    if (!restOptions.host && !restOptions.rootUrl) {
       throw new Error('You must provide a host in the config');
+    }
+
+    if (restOptions.host && restOptions.rootUrl) {
+      throw new Error('You must either provide a host or a rootUrl in the config');
     }
 
     if (restOptions.services) {
@@ -100,6 +105,9 @@ export default class Rest {
   }
 
   static generateRootUrl(restOptions) {
+    if (restOptions.rootUrl) {
+      return restOptions.rootUrl;
+    }
     let url = `${restOptions.unsecure ? 'http' : 'https'}://${restOptions.host}`;
 
     if (restOptions.port) {

--- a/test/unit/services/qix/index.spec.js
+++ b/test/unit/services/qix/index.spec.js
@@ -80,6 +80,11 @@ describe('Qix', () => {
       prefix: '/myproxy/',
       subpath: 'dataprepservice',
     }, 'myApp7')).to.equal('wss://localhost:4848/myproxy/dataprepservice/app/myApp7');
+
+    expect(qix.buildUrl('')).to.equal('');
+    expect(qix.buildUrl(
+      'wss://localhost:4848/myproxy/app/myApp6/identity/migration-service?reloadUri=http%3A%2F%2Fqlik.com'
+    )).to.equal('wss://localhost:4848/myproxy/app/myApp6/identity/migration-service?reloadUri=http%3A%2F%2Fqlik.com');
   });
 
   describe('getGlobal', () => {

--- a/test/unit/services/rest/index.spec.js
+++ b/test/unit/services/rest/index.spec.js
@@ -30,6 +30,12 @@ describe('Rest', () => {
       expect(() => {
         Rest.validateRestOptions(restOptions);
       }).to.not.throw();
+
+      expect(() => {
+        Rest.validateRestOptions({
+          rootUrl: 'http://localhost:60000/custom/api',
+        });
+      }).to.not.throw();
     });
 
     it('should throw errors when service id is missing', () => {
@@ -96,6 +102,14 @@ describe('Rest', () => {
       restOptions.unsecure = false;
       const generatedUrl = Rest.generateRootUrl(restOptions);
       expect(generatedUrl.indexOf('https://') > -1).to.equal(true);
+    });
+
+    it('should support provding a root url', () => {
+      const testedRootUrl = 'http://localhost:60000/custom/api';
+      const generatedUrl = Rest.generateRootUrl({
+        rootUrl: testedRootUrl,
+      });
+      expect(generatedUrl).to.equal(testedRootUrl);
     });
   });
 


### PR DESCRIPTION
### Status

```
* [x] Under development
* [ ] Waiting for code review
* [ ] Waiting for merge
```

### Information

```
* [ ] Contains breaking changes
* [ ] Contains new API(s)
* [ ] Contains documentation
* [X] Contains test
```

### TODO

```
* [ ] Documentation
```