### PR TITLE
correct path to appId

### DIFF
--- a/docs/qix/configuration.md
+++ b/docs/qix/configuration.md
@@ -41,7 +41,7 @@ The `config` object has the following parameters:
 The `qix` object retrieved when calling `getService('qix', config).then((qix) => {})` has the following properties:
 
 * `qix.global` Object - The global instance
-* `qix.app` Object (optional) - The opened app instance if `config.session.appId` was specified.
+* `qix.app` Object (optional) - The opened app instance if `config.appId` was specified.
 
 
 ## Example using the browser


### PR DESCRIPTION
Just a change to documentation, I think `appId` is at the root of the `config` object, not inside `config.session` ... also testing the waters of submitting a pull request...