### PR TITLE
Bump node in circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 4.4.5
+    version: 6.9.5
 
 general:
   artifacts:


### PR DESCRIPTION
Circle CI seems to have issues finding the current 4.4.5 version. Trying to bump to latest LTS version to see if it solved it.