### PR TITLE
Correct handling of the "unsecure" configuration property

### DIFF
--- a/src/services/qix/index.js
+++ b/src/services/qix/index.js
@@ -262,8 +262,8 @@ export default class Qix {
       }
     }
 
-    if (typeof config.secure === 'undefined') {
-      config.secure = !config.unsecure;
+    if (typeof config.session.secure === 'undefined') {
+      config.session.secure = !config.session.unsecure;
     }
 
     if (!config.appId && !config.session.route) {

--- a/test/unit/services/qix/index.spec.js
+++ b/test/unit/services/qix/index.spec.js
@@ -430,13 +430,27 @@ describe('Qix', () => {
     let config;
 
     beforeEach(() => {
-      config = {};
+      config = {
+        session: {},
+      };
+    });
+
+    it('should set secure by default', () => {
+      Qix.configureDefaults(config);
+      expect(config.session.secure).to.equal(true);
     });
 
     it('should convert unsecure parameter to secure if the secure parameter is not set', () => {
-      config.unsecure = false;
+      config.session.unsecure = false;
       Qix.configureDefaults(config);
-      expect(config.secure).to.equal(true);
+      expect(config.session.secure).to.equal(true);
+    });
+
+    it('should give secure precedence', () => {
+      config.session.secure = true;
+      config.session.unsecure = true;
+      Qix.configureDefaults(config);
+      expect(config.session.secure).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
This commit makes sure that use of the deprecated "unsecure"
configuration property still works.

### Status

* [ ] Under development
* [X] Waiting for code review
* [ ] Waiting for merge

### Information

* [ ] Contains breaking changes
* [ ] Contains new API(s)
* [ ] Contains documentation
* [X] Contains test

