### PR TITLE
Add statuscode error handling for rest service

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
     "rimraf": "^2.5.1",
     "swagger-client": "^2.1.23",
     "webpack": "^1.13.1",
-    "ws": "^1.1.1"
+    "ws": "^1.1.1",
+    "nock": "^9.0.10"
   },
-  "dependencies": {}
+  "dependencies": {
+  }
 }

--- a/src/services/rest/http-client.js
+++ b/src/services/rest/http-client.js
@@ -59,7 +59,7 @@ export function responseHandler(opts, res, handleLog) {
       opts.on.response(res);
     } else {
       if (handleLog) {
-        handleLog({ msg: 'Error', data: res });
+        handleLog({ msg: 'Received', data: { status: res.status, statusText: res.statusText } });
       }
       opts.on.error(res);
     }
@@ -74,9 +74,6 @@ export function responseHandler(opts, res, handleLog) {
  * @param {Function} handleLog Logging callback
  */
 export function errorHandler(opts, res, handleLog) {
-  if (handleLog) {
-    handleLog({ msg: 'Error', data: res });
-  }
   // Setup an error object compatible with swagger-client
   const error = {
     status: res.code,
@@ -87,6 +84,9 @@ export function errorHandler(opts, res, handleLog) {
     error.errObj.message = '';
   }
 
+  if (handleLog) {
+    handleLog({ msg: 'Received', data: { status: error.status, statusText: error.statusText } });
+  }
   opts.on.error(error);
 }
 

--- a/src/services/rest/http-client.js
+++ b/src/services/rest/http-client.js
@@ -43,7 +43,7 @@ export function responseHandler(opts, res, handleLog) {
     const response = data.join('');
 
     // Add additional fields compatible with swagger-client
-    res.status = res.statusCode
+    res.status = res.statusCode;
     res.statusText = res.statusMessage;
 
     if (HTTP_200_OK_RANGE_START <= res.statusCode && res.statusCode <= HTTP_200_OK_RANGE_END) {
@@ -80,9 +80,13 @@ export function errorHandler(opts, res, handleLog) {
   // Setup an error object compatible with swagger-client
   const error = {
     status: res.code,
-    statusText: res.message,
+    statusText: res.message || '',
     errObj: res,
   };
+  if (!error.errObj.message) {
+    error.errObj.message = '';
+  }
+
   opts.on.error(error);
 }
 

--- a/src/services/rest/http-client.js
+++ b/src/services/rest/http-client.js
@@ -3,6 +3,8 @@ import url from 'url';
 // see getDefaultHTTPModule for additional imports due to webpack
 
 const IS_NODE = typeof window === 'undefined';
+const HTTP_200_OK_RANGE_START = 200;
+const HTTP_200_OK_RANGE_END = 299;
 
 function getDefaultHTTPModule(secure) {
   /* eslint no-eval:0, global-require:0 */
@@ -39,17 +41,49 @@ export function responseHandler(opts, res, handleLog) {
   res.on('data', data.push.bind(data));
   res.on('end', () => {
     const response = data.join('');
-    res.data = response;
-    try {
-      res.obj = JSON.parse(response);
-    } catch (ex) {
-      // do not set out.obj
+
+    // Add additional fields compatible with swagger-client
+    res.status = res.statusCode
+    res.statusText = res.statusMessage;
+
+    if (HTTP_200_OK_RANGE_START <= res.statusCode && res.statusCode <= HTTP_200_OK_RANGE_END) {
+      res.data = response;
+      try {
+        res.obj = JSON.parse(response);
+      } catch (ex) {
+        // do not set out.obj
+      }
+      if (handleLog) {
+        handleLog({ msg: 'Received', data: { body: res.data } });
+      }
+      opts.on.response(res);
+    } else {
+      if (handleLog) {
+        handleLog({ msg: 'Error', data: res });
+      }
+      opts.on.error(res);
     }
-    if (handleLog) {
-      handleLog({ msg: 'Received', data: { body: res.data } });
-    }
-    opts.on.response(res);
   });
+}
+
+/**
+ * Handles connection errors
+ * @private
+ * @param {ServiceRequestOptions} opts The options for the service request.
+ * @param {Object} res The HTTP response object.
+ * @param {Function} handleLog Logging callback
+ */
+export function errorHandler(opts, res, handleLog) {
+  if (handleLog) {
+    handleLog({ msg: 'Error', data: res });
+  }
+  // Setup an error object compatible with swagger-client
+  const error = {
+    status: res.code,
+    statusText: res.message,
+    errObj: res,
+  };
+  opts.on.error(error);
 }
 
 /**
@@ -143,7 +177,8 @@ export default class HttpClient {
     if (restOpts.handleLog) {
       restOpts.handleLog({ msg: 'Sent', data: { request: settings, body: opts.body || null } });
     }
-    req.on('error', opts.on.error);
+    /* istanbul ignore next */
+    req.on('error', err => errorHandler(opts, err, restOpts.handleLog));
     /* istanbul ignore next */
     req.on('response', res => responseHandler(opts, res, restOpts.handleLog));
     req.end();

--- a/test/component/rest-error-handling.spec.js
+++ b/test/component/rest-error-handling.spec.js
@@ -1,0 +1,112 @@
+/* eslint-disable arrow-body-style */
+import nock from 'nock';
+import chaiSubset from 'chai-subset';
+import Enigma from '../../src/index';
+
+chai.use(chaiSubset);
+
+describe('Error handling in the rest api', () => {
+  let sandbox;
+  let testConfig;
+  before(() => {
+    nock('http://localhost:4848')
+      .persist()
+      .get('/api/about/v1/openapi')
+      .reply(200, 'Persisting all the way');
+
+    sandbox = sinon.sandbox.create();
+
+    testConfig = { secure: false,
+      host: 'localhost',
+      port: 4747,
+      services: [{ id: 'test', version: 'v1' }],
+    };
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  describe('Failing to connecting to a service in three ways', () => {
+    let scope;
+    beforeEach(() => {
+      scope = nock('http://localhost:4747');
+    });
+
+    it('should fail with a nice text for a bad textual response', () => {
+      scope.get('/api/test/v1/openapi').reply(200, 'bad text');
+      const servicePromise = Enigma.getService('rest', testConfig);
+      return expect(servicePromise).to.eventually.be.rejectedWith('failed to parse JSON/YAML response');
+    });
+
+    it('should fail with a nice text for a 404', () => {
+      scope.get('/api/test/v1/openapi').reply(404, 'Not found');
+      const servicePromise = Enigma.getService('rest', testConfig);
+      return expect(servicePromise).to.eventually.be.rejectedWith('Can\'t read swagger JSON from http://localhost:4747/api/test/v1/openapi');
+    });
+
+    it('should fail with a nice text for connectionrefused', () => {
+      scope.get('/api/test/v1/openapi')
+        .replyWithError({
+          code: 'ECONNREFUSED',
+          errno: 'ECONNREFUSED',
+          syscall: 'connect',
+          address: '127.0.0.1',
+          port: 4747,
+        });
+      const servicePromise = Enigma.getService('rest', testConfig);
+      return expect(servicePromise).to.eventually.be.rejectedWith('ECONNREFUSED :  http://localhost:4747/api/test/v1/openapi');
+    });
+  });
+
+  describe('Succesfully connecting to a service but fail in calling it', () => {
+    let scope;
+    let testService;
+    beforeEach(() => {
+      scope = nock('http://localhost:4747');
+      scope.get('/api/test/v1/openapi').reply(200, JSON.stringify({
+        swagger: '2.0',
+        basePath: '/api/test/v1',
+        paths: {
+          '/test': {
+            get: {
+              responses: {
+                200: {
+                  description: 'OK',
+                },
+              },
+            },
+          },
+        },
+      }));
+
+      return Enigma.getService('rest', testConfig).then((services) => {
+        testService = services.test;
+      });
+    });
+
+    it('should return the expected response from the test call', () => {
+      scope.get('/api/test/v1/test').reply(200, '{"answer":"tested indeed"}');
+      const returnedJsonObject = testService.apis.default.get_test().then(response => response.obj);
+      return expect(returnedJsonObject).to.eventually.deep.equal({ answer: 'tested indeed' });
+    });
+
+    it('should be rejected for a 404', () => {
+      scope.get('/api/test/v1/test').reply(404, 'Not found');
+      const error = testService.apis.default.get_test();
+      return expect(error).to.be.rejected.and.eventually.have.property('status', 404);
+    });
+
+    it('should be rejected for a ECONNREFUSED', () => {
+      scope.get('/api/test/v1/test').replyWithError({
+        code: 'ECONNREFUSED',
+        errno: 'ECONNREFUSED',
+        syscall: 'connect',
+        address: '127.0.0.1',
+        port: 4747,
+      });
+      const error = testService.apis.default.get_test();
+      return expect(error).to.be.rejected.and.eventually.have.property('status', 'ECONNREFUSED');
+    });
+  });
+});

--- a/test/unit/services/rest/http-client.spec.js
+++ b/test/unit/services/rest/http-client.spec.js
@@ -155,7 +155,7 @@ describe('HttpClient (swagger.js compatible)', () => {
     });
 
     it('should handle successful responses', () => {
-      const res = { setEncoding: sinon.spy(), on: sinon.spy() };
+      const res = { statusCode: 200, setEncoding: sinon.spy(), on: sinon.spy() };
       responseHandler(opts, res);
       const dataCallback = res.on.args[0][1];
       dataCallback('Hello');


### PR DESCRIPTION
Now error codes like 404 etc and socket errors like ECONNREFUSED are handled properly in the rest service.

### Status

* [ ] Under development
* [*] Waiting for code review
* [ ] Waiting for merge

### Information

* [ ] Contains breaking changes
* [ ] Contains new API(s)
* [ ] Contains documentation
* [*] Contains test
