### PR TITLE
Remove session cache and disableCache config option

### DIFF
--- a/docs/qix/configuration.md
+++ b/docs/qix/configuration.md
@@ -35,7 +35,6 @@ The `config` object has the following parameters:
 | `session.urlParams` | Object | Yes | Additional parameters to be added to WebSocket URL |
 | `session.subpath` | String | Yes | Subpath to use, used to connect to dataprepservice in a server environment |
 | `session.identity` | String | Yes | Identity (session ID) to use |
-| `session.disableCache` | String | Yes | Disable caching of sessions, set to `true` to create a new session every time |
 | `session.suspendOnClose` | Boolean | Yes | Set to true if the session should be suspended and not closed if the WebSocket is closed unexpectedly |
 | `session.ttl` | Number | Yes | A value in seconds that QIX Engine should keep the session alive after socket disconnect (only works if QIX Engine supports it) |
 

--- a/test/unit/qix.spec.js
+++ b/test/unit/qix.spec.js
@@ -197,40 +197,11 @@ describe('Qix', () => {
   });
 
   describe('getSession', () => {
-    const session = { on: sinon.spy() };
-    let createSession;
-    let add;
-    let remove;
     const rpc = {};
 
     beforeEach(() => {
       sandbox.stub(qix, 'buildUrl').returns('url');
-      sandbox.stub(qix.sessions, 'get').returns(undefined);
       sandbox.stub(qix, 'createRPC').returns(rpc);
-      createSession = sandbox.stub(qix, 'createSession').returns(session);
-      add = sandbox.stub(qix.sessions, 'add');
-      remove = sandbox.stub(qix.sessions, 'remove');
-    });
-
-    it('should reuse existing session', () => {
-      const cachedSession = { on: sinon.spy() };
-      qix.sessions.get.returns(cachedSession);
-      const sessionApi = qix.getSession({ delta: true, session: {} });
-      expect(sessionApi).to.equal(cachedSession);
-    });
-
-    it('should not reuse existing session if `disableCache` is truthy', () => {
-      qix.getSession({ delta: true, session: {} });
-      qix.getSession({ delta: true, session: { disableCache: true } });
-      expect(add.callCount).to.equal(1);
-      expect(session.on.callCount).to.equal(1);
-      expect(createSession.callCount).to.equal(2);
-    });
-
-    it('should remove session from cache', () => {
-      qix.getSession({ delta: true, session: {} });
-      session.on.callArg(1);
-      expect(remove).to.have.been.calledWithExactly('url');
     });
   });
 


### PR DESCRIPTION
Fixes #66

Note: This changes the behaviour of `getService()` when `appId` is defined (it will _always_ create a new session/socket for globals/openDoc)