### PR TITLE
Resume using opendoc params

### DIFF
--- a/examples/car-models/src/app.js
+++ b/examples/car-models/src/app.js
@@ -47,8 +47,8 @@ angular.module('app', []).component('app', {
               location.href = authInfo.loginUri;
             }
           },
+          'traffic:*': (dir, data) => console.log(dir, data),
         },
-        handleLog: logRow => console.log(logRow),
       };
       enigma.connect(config).then((qix) => {
         this.connected = true;

--- a/examples/list-apps/index.js
+++ b/examples/list-apps/index.js
@@ -25,7 +25,9 @@ const config = {
       },
     });
   },
-  handleLog: logRow => console.log(logRow),
+  listeners: {
+    'traffic:*': (dir, data) => console.log(dir, data),
+  },
 };
 
 console.log('Connecting to Engine');

--- a/src/qix.js
+++ b/src/qix.js
@@ -146,6 +146,8 @@ class Qix {
         const appSession = Qix.getSession(config);
 
         if (!appSession.apiPromise) {
+          // create a Global API for this session:
+          appSession.getObjectApi(args);
           appSession.apiPromise = appSession.connect().then(() =>
             appSession.send({
               method: 'OpenDoc',

--- a/src/qix.js
+++ b/src/qix.js
@@ -50,40 +50,6 @@ function replaceLeadingAndTrailingSlashes(str) {
 class Qix {
 
   /**
-  * Function used to create a session.
-  * @param {Object} rpc The RPC instance used by the session.
-  * @param {Boolean} delta=true Flag to determine delta handling.
-  * @param {Object} schema The Definition used by the session.
-  * @param {Object} JSONPatch JSON patch object.
-  * @param {Function} Promise The promise constructor.
-  * @param {Object} listeners A key-value map of listeners.
-  * @param {Array} interceptors An array of interceptors.
-  * @param {Function} log handler callback
-  * @param {String} appId - the appId for this session.
-  * @param {Boolean} noData - if true, the app was opened without data.
-  * @param {Boolean} suspendOnClose - when true, the session will be suspended if the underlying
-  *                                   websocket closes unexpectedly.
-  * @returns {Object} Returns an instance of Session.
-  */
-  static createSession(rpc, delta, schema, JSONPatch, Promise, listeners, interceptors, handleLog,
-    appId, noData, suspendOnClose) {
-    return new Session(rpc, delta, schema, JSONPatch, Promise, listeners, interceptors, handleLog,
-      appId, noData, suspendOnClose);
-  }
-
-  /**
-  * Function used to create an RPC.
-  * @param {Function} Promise The promise constructor.
-  * @param {String} url The URL used to connect to an endpoint.
-  * @param {Function} createSocket The function callback to create a WebSocket.
-  * @param {SessionConfiguration} sessionConfig - The session configuration object.
-  * @returns {Object} Returns an instance of RPC.
-  */
-  static createRPC(Promise, url, createSocket, sessionConfig) {
-    return new RPC(Promise, url, createSocket, sessionConfig);
-  }
-
-  /**
   * Function used to build an URL.
   * @param {SessionConfiguration} sessionConfig - The session configuration object.
   * @param {String} [appId] The optional app id.
@@ -147,8 +113,8 @@ class Qix {
   */
   static getSession(config) {
     const url = Qix.buildUrl(config.session, config.appId);
-    const rpc = Qix.createRPC(config.Promise, url, config.createSocket, config.session);
-    const session = Qix.createSession(
+    const rpc = new RPC(config.Promise, url, config.createSocket, config.session);
+    const session = new Session(
         rpc,
         config.delta,
         config.schema,
@@ -156,9 +122,6 @@ class Qix {
         config.Promise,
         config.listeners,
         config.responseInterceptors,
-        config.handleLog,
-        config.appId,
-        config.noData,
         config.session.suspendOnClose
       );
     return session;
@@ -177,8 +140,6 @@ class Qix {
       const globalApi = session.getObjectApi(args);
       globalApi.openApp = globalApi.openDoc =
       (appId, user = '', password = '', serial = '', noData = false) => {
-        session.appId = appId;
-        session.noData = noData;
         config.session.route = '';
         config.appId = appId;
 

--- a/src/session.js
+++ b/src/session.js
@@ -22,14 +22,13 @@ class Session {
   * @param {Function} Promise - The promise constructor.
   * @param {Object} listeners - A key-value map of listeners.
   * @param {Array} interceptors - An array of interceptors.
-  * @param {Function} handleLog - log handler callback
   * @param {String} appId - the appId for this session.
   * @param {Boolean} noData - if true, the app was opened without data.
   * @param {Boolean} suspendOnClose - when true, the session will be suspended if the underlying
   *                                   websocket closes unexpectedly.
   */
   constructor(rpc, delta, definition, JSONPatch, Promise, listeners = {},
-    interceptors = [], handleLog, appId, noData, suspendOnClose) {
+    interceptors = [], suspendOnClose) {
     Events.mixin(this);
     this.rpc = rpc;
     this.delta = delta;
@@ -37,14 +36,9 @@ class Session {
     this.JSONPatch = JSONPatch;
     this.Promise = Promise;
     this.apis = new ApiCache();
-    this.handleLog = handleLog;
-    this.appId = appId;
-    this.noData = noData;
     this.suspendOnClose = suspendOnClose;
     this.connectionId = connectionIdCounter += 1;
     this.responseInterceptors = [{
-      onFulfilled: this.processLogInterceptor,
-    }, {
       onFulfilled: this.processErrorInterceptor,
     }, {
       onFulfilled: this.processDeltaInterceptor,
@@ -430,20 +424,6 @@ class Session {
       , promise
     );
   }
-
-  /**
-   * Log interceptor.
-   * @param {Object} meta - The meta info about the request.
-   * @param response - The response.
-   * @returns {Object} - Returns the defined error for an error, else the response.
-   */
-  processLogInterceptor(meta, response) {
-    if (this.handleLog) {
-      this.handleLog({ msg: 'Received', connection: this.connectionId, data: response });
-    }
-    return response;
-  }
-
 
   /**
   * Process error interceptor.

--- a/src/session.js
+++ b/src/session.js
@@ -22,8 +22,6 @@ class Session {
   * @param {Function} Promise - The promise constructor.
   * @param {Object} listeners - A key-value map of listeners.
   * @param {Array} interceptors - An array of interceptors.
-  * @param {String} appId - the appId for this session.
-  * @param {Boolean} noData - if true, the app was opened without data.
   * @param {Boolean} suspendOnClose - when true, the session will be suspended if the underlying
   *                                   websocket closes unexpectedly.
   */
@@ -169,6 +167,10 @@ class Session {
     this.emit('traffic:*', 'sent', request);
     this.emit('traffic:sent', request);
 
+    if (request.method === 'OpenDoc') {
+      this.openDocParams = request.params;
+    }
+
     const promise = this.intercept(response, this.responseInterceptors, request);
     Session.addToPromiseChain(promise, 'requestId', request.id);
     return promise;
@@ -228,11 +230,11 @@ class Session {
       handle: -1,
       params: [],
     }).then((response) => {
-      if (response.error) {
+      if (response.error && this.openDocParams) {
         return this.rpc.send({
           method: 'OpenDoc',
           handle: -1,
-          params: [this.appId, '', '', '', !!this.noData],
+          params: this.openDocParams,
         });
       }
       return response;

--- a/test/integration/index.html
+++ b/test/integration/index.html
@@ -19,7 +19,7 @@
     }
 
     function run() {
-      enigma.create({
+      enigma.connect({
         listeners: {
           'notification:OnAuthenticationInformation': function(data) {
             if (data.mustAuthenticate === true) {

--- a/test/unit/qix.spec.js
+++ b/test/unit/qix.spec.js
@@ -1,8 +1,6 @@
 import Promise from 'bluebird';
 import Patch from '../../src/json-patch';
-import RPC from '../../src/rpc';
 import Qix from '../../src/qix';
-import Session from '../../src/session';
 import Schema from '../../src/schema';
 
 describe('Qix', () => {
@@ -19,14 +17,6 @@ describe('Qix', () => {
   it('should be a constructor', () => {
     expect(Qix).to.be.a('function');
     expect(Qix).to.throw();
-  });
-
-  it('should create a session', () => {
-    expect(Qix.createSession({ on() {} }, {}, {}, {}, () => {})).to.be.an.instanceOf(Session);
-  });
-
-  it('should create a RPC', () => {
-    expect(Qix.createRPC(() => {}, () => {}, '', {})).to.be.an.instanceOf(RPC);
   });
 
   it('should build an url depending on config', () => {


### PR DESCRIPTION
* For some reason I think I searched case-sensitive in #83, missing quite a few places where `handleLog` was referenced
* Switched resume logic over to using a stored opendoc params array instead
* Added another integration test which covers suspend/resume on a non-existing session where the doc should still be restored seamlessly
