### PR TITLE
Refactored session

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015"],
+  "plugins": ["transform-object-assign"]
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "after-work.js": "^2.0.0",
     "babel-core": "^6.10.4",
     "babel-plugin-external-helpers": "^6.22.0",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-es2015-rollup": "^3.0.0",
     "babel-register": "^6.7.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,7 +18,14 @@ export default {
     nodeGlobals(),
     nodeBuiltins(),
     commonjs(),
-    babel({ exclude: 'node_modules/**', babelrc: false, presets: ['es2015-rollup'], plugins: ['external-helpers'] }),
+    babel({
+      exclude: 'node_modules/**',
+      // we need to disable the rc file since we need the modules support
+      // to run our tests (which is disabled in rollup):
+      babelrc: false,
+      presets: ['es2015-rollup'],
+      plugins: ['external-helpers', 'transform-object-assign'],
+    }),
     uglify(),
     filesize(),
   ],

--- a/src/api-cache.js
+++ b/src/api-cache.js
@@ -1,19 +1,27 @@
 import KeyValueCache from './cache';
 
 /**
-* API cache.
+* API cache for instances of QIX types, e.g. GenericObject.
 * @extends KeyValueCache
 */
 class ApiCache extends KeyValueCache {
 
   /**
-  * Constructor
+  * Create a new ApiCache instance.
+  * @param {Object} options The configuration options for this class.
+  * @param {Promise} options.Promise The promise constructor to use.
+  * @param {Schema} options.schema The schema instance to use.
   */
-  constructor(opts) {
+  constructor(options) {
     super();
-    Object.assign(this, opts);
+    Object.assign(this, options);
   }
 
+  /**
+  * Event handler for triggering API instance events when their handle
+  * is changed.
+  * @emits api#changed
+  */
   onHandleChanged(handle) {
     const api = this.getApi(handle);
     if (api) {
@@ -21,6 +29,11 @@ class ApiCache extends KeyValueCache {
     }
   }
 
+  /**
+  * Event handler for triggering API instance events when their handle
+  * is closed.
+  * @emits api#closed
+  */
   onHandleClosed(handle) {
     const api = this.getApi(handle);
     if (api) {
@@ -29,6 +42,10 @@ class ApiCache extends KeyValueCache {
     }
   }
 
+  /**
+  * Event handler for cleaning up API instances when a session has been closed.
+  * @emits api#closed
+  */
   onSessionClosed() {
     this.getApis().forEach((entry) => {
       entry.api.emit('closed');
@@ -39,6 +56,7 @@ class ApiCache extends KeyValueCache {
 
   /**
   * Function used to get an API for a backend object.
+  * Requires a session instance on `this.session`.
   * @param {Object} args - Arguments used to create object API.
   * @param {Number} args.handle - Handle of the backend object.
   * @param {String} args.id - ID of the backend object.

--- a/src/intercept.js
+++ b/src/intercept.js
@@ -1,6 +1,15 @@
 const RETURN_KEY = 'qReturn';
 
 class Intercept {
+  /**
+  * Create a new Intercept instance.
+  * @param {Object} options The configuration options for this class.
+  * @param {Promise} options.Promise The promise constructor to use.
+  * @param {ApiCache} options.apis The ApiCache instance to use.
+  * @param {Boolean} options.delta Whether to use the delta protocol.
+  * @param {Array} [options.interceptors] Additional interceptors to use.
+  * @param {JSONPatch} [options.JSONPatch] The JSONPatch implementation to use (for testing).
+  */
   constructor(options) {
     Object.assign(this, options);
     this.interceptors = [{
@@ -182,6 +191,13 @@ class Intercept {
     return response;
   }
 
+  /**
+  * Execute the interceptor queue, each interceptor will get the result from
+  * the previous interceptor.
+  * @param {Promise} promise The promise to chain on to.
+  * @param {Object} meta The JSONRPC request object for the intercepted response.
+  * @returns {Promise}
+  */
   execute(promise, meta) {
     return this.interceptors.reduce((interception, interceptor) =>
       interception.then(

--- a/src/intercept.js
+++ b/src/intercept.js
@@ -1,0 +1,195 @@
+const RETURN_KEY = 'qReturn';
+
+class Intercept {
+  constructor(options) {
+    Object.assign(this, options);
+    this.interceptors = [{
+      onFulfilled: this.processErrorInterceptor,
+    }, {
+      onFulfilled: this.processDeltaInterceptor,
+    }, {
+      onFulfilled: this.processResultInterceptor,
+    }, {
+      onFulfilled: this.processMultipleOutParamInterceptor,
+    }, {
+      onFulfilled: this.processOutInterceptor,
+    }, {
+      onFulfilled: this.processObjectApiInterceptor,
+    }, ...this.interceptors || []];
+  }
+
+  /**
+  * Function used to determine if it is a primitive patch.
+  * @param  {Array}  patches Patches from engine.
+  * @return {Boolean} Returns true if it is a primitive patch.
+  */
+  isPrimitivePatch(patches) {
+    // It's only `add` and `replace` that has a
+    // value property according to the jsonpatch spec
+    return patches.length === 1 &&
+    ['add', 'replace'].indexOf(patches[0].op) !== -1 &&
+    this.isPrimitiveValue(patches[0].value) &&
+    patches[0].path === '/';
+  }
+
+  /**
+  * Function used to determine if it is a primitive value.
+  * @param  {Any} value.
+  * @return {Boolean} Returns true if it is a primitive value.
+  */
+  isPrimitiveValue(value) {
+    return typeof value !== 'undefined' && value !== null && typeof value !== 'object' && !Array.isArray(value);
+  }
+
+  /**
+  * Function used to get a patchee.
+  * @param {Number} handle - The handle.
+  * @param {Array} patches - The patches.
+  * @param {String} cacheId - The cacheId.
+  * @returns {Object} Returns the patchee.
+  */
+  getPatchee(handle, patches, cacheId) {
+    // handle primitive types, e.g. string, int, bool
+    if (this.isPrimitivePatch(patches)) {
+      const value = patches[0].value;
+      this.apis.setPatchee(handle, cacheId, value);
+      return value;
+    }
+
+    let patchee = this.apis.getPatchee(handle, cacheId);
+
+    if (!this.isPrimitiveValue(patchee)) {
+      patchee = patchee || (patches.length && Array.isArray(patches[0].value) ? [] : {});
+      this.applyPatch(patchee, patches);
+    }
+
+    this.apis.setPatchee(handle, cacheId, patchee);
+
+    return patchee;
+  }
+
+  /**
+  * Function used to apply a patch.
+  * @param {Object} patchee - The object to patch.
+  * @param {Array} patches - The list of patches to apply.
+  */
+  applyPatch(patchee, patches) {
+    this.JSONPatch.apply(patchee, patches);
+  }
+
+  /**
+  * Process error interceptor.
+  * @param {Object} meta - The meta info about the request.
+  * @param response - The response.
+  * @returns {Object} - Returns the defined error for an error, else the response.
+  */
+  processErrorInterceptor(meta, response) {
+    if (typeof response.error !== 'undefined') {
+      return this.Promise.reject(response.error);
+    }
+    return response;
+  }
+
+  /**
+  * Process delta interceptor.
+  * @param {Object} meta - The meta info about the request.
+  * @param response - The response.
+  * @returns {Object} - Returns the patched response
+  */
+  processDeltaInterceptor(meta, response) {
+    const result = response.result;
+    if (response.delta) {
+      // when delta is on the response data is expected to be an array of patches
+      const keys = Object.keys(result);
+      for (let i = 0, cnt = keys.length; i < cnt; i += 1) {
+        const key = keys[i];
+        const patches = result[key];
+        if (!Array.isArray(patches)) {
+          return this.Promise.reject('Unexpected rpc response, expected array of patches');
+        }
+        result[key] = this.getPatchee(meta.handle, patches, `${meta.method}-${key}`);
+      }
+      // return a cloned response object to avoid patched object references:
+      return JSON.parse(JSON.stringify(response));
+    }
+    return response;
+  }
+
+  /**
+  * Process result interceptor.
+  * @param {Object} meta - The meta info about the request.
+  * @param response - The response.
+  * @returns {Object} - Returns the result property on the response
+  */
+  processResultInterceptor(meta, response) {
+    return response.result;
+  }
+
+  /**
+  * Processes specific QIX methods that are breaking the protocol specification
+  * and normalizes the response.
+  * @param {Object} meta - The meta info about the request.
+  * @param response - The response.
+  * @returns {Object} - Returns the result property on the response
+  */
+  processMultipleOutParamInterceptor(meta, response) {
+    if (meta.method === 'CreateSessionApp' || meta.method === 'CreateSessionAppFromApp') {
+      // this method returns multiple out params that we need
+      // to normalize before processing the response further:
+      response[RETURN_KEY].qGenericId = response[RETURN_KEY].qGenericId || response.qSessionAppId;
+    } else if (meta.method === 'GetInteract') {
+      // this method returns a qReturn value when it should only return
+      // meta.outKey:
+      delete response[RETURN_KEY];
+    }
+    return response;
+  }
+
+  /**
+  * Process out interceptor.
+  * @param {Object} meta - The meta info about the request.
+  * @param response - The result.
+  * @returns {Object} - Returns the out property on result
+  */
+  processOutInterceptor(meta, response) {
+    if (hasOwnProperty.call(response, RETURN_KEY)) {
+      return response[RETURN_KEY];
+    } else if (meta.outKey !== -1) {
+      return response[meta.outKey];
+    }
+    return response;
+  }
+
+  /**
+  * Function used to process the object API interceptor.
+  * @param {Object} meta - The meta info about the request.
+  * @param response - The response.
+  * @returns {Object} - Returns an object API or the response.
+  */
+  processObjectApiInterceptor(meta, response) {
+    if (response.qHandle && response.qType) {
+      return this.apis.getObjectApi({
+        handle: response.qHandle,
+        type: response.qType,
+        id: response.qGenericId,
+        customType: response.qGenericType,
+        delta: this.delta,
+      });
+    } else if (response.qHandle === null && response.qType === null) {
+      // TODO: reject?
+      return null;
+    }
+    return response;
+  }
+
+  execute(promise, meta) {
+    return this.interceptors.reduce((interception, interceptor) =>
+      interception.then(
+      interceptor.onFulfilled && interceptor.onFulfilled.bind(this, meta),
+      interceptor.onRejected && interceptor.onRejected.bind(this, meta))
+      , promise
+    );
+  }
+}
+
+export default Intercept;

--- a/src/rpc.js
+++ b/src/rpc.js
@@ -8,9 +8,10 @@ class RPC {
 
   /**
   * Create a new RPC instance.
-  * @param {Function} Promise - The promise constructor.
-  * @param {String} url - The URL used to connect to an endpoint.
-  * @param {Function} createSocket The function callback to create a WebSocket.
+  * @param {Object} options The configuration options for this class.
+  * @param {Function} options.Promise The promise constructor to use.
+  * @param {String} options.url The complete websocket URL used to connect.
+  * @param {Function} options.createSocket The function callback to create a WebSocket.
   */
   constructor(options) {
     Object.assign(this, options);

--- a/src/session.js
+++ b/src/session.js
@@ -1,537 +1,107 @@
-import Events from './event-emitter';
-import ApiCache from './api-cache';
+import EventEmitter from './event-emitter';
 
-const RETURN_KEY = 'qReturn';
 const RPC_CLOSE_NORMAL = 1000;
 const RPC_CLOSE_MANUAL_SUSPEND = 4000;
-const ON_ATTACHED_TIMEOUT_MS = 5000;
-const hasOwnProperty = Object.prototype.hasOwnProperty;
 
-let connectionIdCounter = 0;
-/**
-* Session - Handles a session against an endpoint
-*/
 class Session {
-
-  /**
-  * Constructor
-  * @param {Object} rpc - The RPC instance used by the session.
-  * @param {Boolean} delta=true - Flag to determine delta handling.
-  * @param {Object} definition - The definition instance used by the session.
-  * @param {Object} JSONPatch - JSON patch object.
-  * @param {Function} Promise - The promise constructor.
-  * @param {Object} listeners - A key-value map of listeners.
-  * @param {Array} interceptors - An array of interceptors.
-  * @param {Boolean} suspendOnClose - when true, the session will be suspended if the underlying
-  *                                   websocket closes unexpectedly.
-  */
-  constructor(rpc, delta, definition, JSONPatch, Promise, listeners = {},
-    interceptors = [], suspendOnClose) {
-    Events.mixin(this);
-    this.rpc = rpc;
-    this.delta = delta;
-    this.definition = definition;
-    this.JSONPatch = JSONPatch;
-    this.Promise = Promise;
-    this.apis = new ApiCache();
-    this.suspendOnClose = suspendOnClose;
-    this.connectionId = connectionIdCounter += 1;
-    this.responseInterceptors = [{
-      onFulfilled: this.processErrorInterceptor,
-    }, {
-      onFulfilled: this.processDeltaInterceptor,
-    }, {
-      onFulfilled: this.processResultInterceptor,
-    }, {
-      onFulfilled: this.processMultipleOutParamInterceptor,
-    }, {
-      onFulfilled: this.processOutInterceptor,
-    }, {
-      onFulfilled: this.processObjectApiInterceptor,
-    }];
-    this.responseInterceptors.push(...interceptors);
-    this.registerRpcListeners();
-
-    this.suspended = false;
-
-    this.on('handle-changed', (handle) => {
-      const api = this.apis.getApi(handle);
-      if (api) {
-        api.emit('changed');
-      }
-    });
-
-    this.on('handle-closed', (handle) => {
-      const api = this.apis.getApi(handle);
-      if (api) {
-        api.emit('closed');
-        this.apis.remove(handle);
-      }
-    });
-
-    this.on('suspended', () => {
-      this.suspended = true;
-    });
-
-    this.on('closed', () => {
-      this.removeAllListeners();
-      this.apis.getApis().forEach((entry) => {
-        entry.api.emit('closed');
-        entry.api.removeAllListeners();
-      });
-      this.apis.clear();
-    });
-
-    Object.keys(listeners).forEach(key => this.on(key, listeners[key]));
-    this.emit('session-created', this);
+  constructor(options) {
+    const session = this;
+    Object.assign(session, options);
+    EventEmitter.mixin(session);
+    // api cache needs a session reference:
+    session.apis.session = session;
+    session.rpc.on('socket-error', session.onError.bind(session));
+    session.rpc.on('closed', session.onClosed.bind(session));
+    session.rpc.on('message', session.onMessage.bind(session));
+    session.rpc.on('notification', session.onNotification.bind(session));
+    session.rpc.on('traffic', session.onTraffic.bind(session));
+    session.on('handle-changed', handle => session.apis.onHandleChanged(handle));
+    session.on('handle-closed', handle => session.apis.onHandleClosed(handle));
+    session.on('closed', () => session.apis.onSessionClosed());
+    Object.keys(session.eventListeners || {})
+      .forEach(key => session.on(key, session.eventListeners[key]));
+    session.emit('session-created', session);
   }
 
-  /**
-  * Function used register the RPC listerners except for the notification listeners
-  */
-  registerRpcListeners() {
-    const onError = (err) => {
-      if (this.suspended) {
-        return;
-      }
-      this.emit('socket-error', err);
-    };
-
-    const onClosed = (evt) => {
-      if (this.suspended) {
-        return;
-      }
-      if (evt.code === RPC_CLOSE_NORMAL || evt.code === RPC_CLOSE_MANUAL_SUSPEND) {
-        return;
-      }
-      if (this.suspendOnClose) {
-        this.emit('suspended', { initiator: 'network' });
-      } else {
-        this.emit('closed', evt);
-      }
-    };
-
-    const onMessage = (response) => {
-      if (this.suspended) {
-        return;
-      }
-
-      this.emit('traffic:*', 'received', response);
-      this.emit('traffic:received', response);
-
-      if (response.change) {
-        response.change.forEach(handle => this.emit('handle-changed', handle));
-      }
-      if (response.close) {
-        response.close.forEach(handle => this.emit('handle-closed', handle));
-      }
-    };
-
-    const onNotification = (response) => {
-      this.emit('notification:*', response.method, response.params);
-      this.emit(`notification:${response.method}`, response.params);
-    };
-
-    this.rpc.on('socket-error', onError);
-    this.rpc.on('closed', onClosed);
-    this.rpc.on('message', onMessage);
-    this.rpc.on('notification', onNotification);
+  onError(err) {
+    if (this.suspendResume.isSuspended) {
+      return;
+    }
+    this.emit('socket-error', err);
   }
 
-  /**
-  * Function used to connect to the endpoint.
-  * @returns {Object} Returns a promise instance.
-  */
+  onClosed(evt) {
+    if (this.suspendResume.isSuspended) {
+      return;
+    }
+    if (evt.code === RPC_CLOSE_NORMAL || evt.code === RPC_CLOSE_MANUAL_SUSPEND) {
+      return;
+    }
+    if (this.suspendOnClose) {
+      this.emit('suspended', { initiator: 'network' });
+    } else {
+      this.emit('closed', evt);
+    }
+  }
+
+  onMessage(response) {
+    if (this.suspendResume.isSuspended) {
+      return;
+    }
+    if (response.change) {
+      response.change.forEach(handle => this.emit('handle-changed', handle));
+    }
+    if (response.close) {
+      response.close.forEach(handle => this.emit('handle-closed', handle));
+    }
+  }
+
+  onNotification(response) {
+    this.emit('notification:*', response.method, response.params);
+    this.emit(`notification:${response.method}`, response.params);
+  }
+
+  onTraffic(dir, data) {
+    this.emit('traffic:*', dir, data);
+    this.emit(`traffic:${dir}`, data);
+  }
+
   connect() {
     return this.rpc.open();
   }
 
-  /**
-  * Function used to send data to the endpoint.
-  * @param {Object} request - The request to be sent. (data and some meta info)
-  * @returns {Object} Returns a promise instance.
-  */
   send(request) {
-    if (this.suspended) {
+    if (this.suspendResume.isSuspended) {
       return this.Promise.reject(new Error('Session suspended'));
     }
-
     const data = {
       method: request.method,
       handle: request.handle,
       params: request.params,
       delta: request.delta,
-      // TODO: add cont & return_empty when needed/used
     };
     const response = this.rpc.send(data);
     request.id = data.id;
-
-    this.emit('traffic:*', 'sent', request);
-    this.emit('traffic:sent', request);
-
-    if (request.method === 'OpenDoc') {
-      this.openDocParams = request.params;
-    }
-
-    const promise = this.intercept(response, this.responseInterceptors, request);
+    const promise = this.intercept.execute(response, request);
     Session.addToPromiseChain(promise, 'requestId', request.id);
     return promise;
   }
 
-  /**
-  * Function used to suspend the session.
-  * @returns {Object} Returns a promise instance.
-  */
   suspend() {
+    this.suspendResume.suspend();
     return this.rpc.close(RPC_CLOSE_MANUAL_SUSPEND)
       .then(() => this.emit('suspended', { initiator: 'manual' }));
   }
 
-  /**
-  * Function used to restore the rpc connection.
-  * @param {Boolean} onlyIfAttached - if true, the returned promise will resolve
-  *                                   only if the session can be re-attached.
-  * @returns {Object} Returns a promise instance.
-  */
-  restoreRpcConnection(onlyIfAttached) {
-    return this.rpc.reopen(ON_ATTACHED_TIMEOUT_MS).then((sessionState) => {
-      if (sessionState === 'SESSION_CREATED' && onlyIfAttached) {
-        return this.Promise.reject(new Error('Not attached'));
-      }
-      return this.Promise.resolve();
+  resume(onlyIfAttached) {
+    return this.suspendResume.resume(onlyIfAttached).then((value) => {
+      this.emit('resumed');
+      return value;
     });
   }
 
-  /**
-  * Function used to restore the global API.
-  * @param {Object} changed - A list where the restored APIs will be added.
-  * @returns {Object} Returns a promise instance.
-  */
-  restoreGlobal(changed) {
-    const global = this.apis.getApisByType('Global').pop();
-    changed.push(global.api);
-    return this.Promise.resolve();
-  }
-
-  /**
-  * Function used to restore the doc API.
-  * @param {String} sessionState - The state of the session, attached or created.
-  * @param {Array} closed - A list where the closed of APIs APIs will be added.
-  * @param {Object} changed - A list where the restored APIs will be added.
-  * @returns {Object} Returns a promise instance.
-  */
-  restoreDoc(closed, changed) {
-    const doc = this.apis.getApisByType('Doc').pop();
-
-    if (!doc) {
-      return this.Promise.resolve();
-    }
-
-    return this.rpc.send({
-      method: 'GetActiveDoc',
-      handle: -1,
-      params: [],
-    }).then((response) => {
-      if (response.error && this.openDocParams) {
-        return this.rpc.send({
-          method: 'OpenDoc',
-          handle: -1,
-          params: this.openDocParams,
-        });
-      }
-      return response;
-    }).then((response) => {
-      if (response.error) {
-        closed.push(doc.api);
-        return this.Promise.resolve();
-      }
-      const handle = response.result.qReturn.qHandle;
-      doc.api.handle = handle;
-      changed.push(doc.api);
-      return this.Promise.resolve(doc.api);
-    });
-  }
-
-  /**
-  * Function used to restore the APIs on the doc.
-  * @param {Object} doc - The doc API on which the APIs we want to restore exist.
-  * @param {Array} closed - A list where the closed of APIs APIs will be added.
-  * @param {Object} changed - A list where the restored APIs will be added.
-  * @returns {Object} Returns a promise instance.
-  */
-  restoreDocObjects(doc, closed, changed) {
-    const tasks = [];
-    const apis = this.apis.getApis()
-      .map(entry => entry.api)
-      .filter(api => api.type !== 'Global' && api.type !== 'Doc');
-
-    if (!doc) {
-      apis.forEach(api => closed.push(api));
-      return this.Promise.resolve();
-    }
-
-    apis.forEach((api) => {
-      const method = Session.buildGetMethodName(api.type);
-
-      if (!method) {
-        closed.push(api);
-      } else {
-        const request = this.rpc.send({
-          method,
-          handle: doc.handle,
-          params: [api.id],
-        }).then((response) => {
-          if (response.error || !response.result.qReturn.qHandle) {
-            closed.push(api);
-          } else {
-            api.handle = response.result.qReturn.qHandle;
-            changed.push(api);
-          }
-        });
-        tasks.push(request);
-      }
-    });
-    return Promise.all(tasks);
-  }
-
-  /**
-  * Function used to resume the session
-  * @param {Boolean} onlyIfAttached - if true, resume only if the session was re-attached.
-  * @returns {Object} Returns a promise instance.
-  */
-  resume(onlyIfAttached = false) {
-    if (!this.suspended) {
-      return this.Promise.resolve();
-    }
-
-    const changed = [];
-    const closed = [];
-
-    return this.restoreRpcConnection(onlyIfAttached)
-      .then(() => this.restoreGlobal(changed))
-      .then(() => this.restoreDoc(closed, changed))
-      .then(doc => this.restoreDocObjects(doc, closed, changed))
-      .then(() => {
-        this.apis = new ApiCache(changed);
-        this.suspended = false;
-        closed.forEach(api => api.emit('closed'));
-        changed.filter(api => api.type !== 'Global').forEach(api => api.emit('changed'));
-        this.emit('resumed');
-      })
-      .catch(err => this.rpc.close().then(() => this.Promise.reject(err)));
-  }
-
-  /**
-  * Function used to close the endpoint.
-  * @returns {Object} Returns a promise instance.
-  */
   close() {
     return this.rpc.close().then(evt => this.emit('closed', evt));
-  }
-
-  /**
-  * Function used to get an API for a backend object.
-  * @param {Object} args - Arguments used to create object API.
-  * @param {Number} args.handle - Handle of the backend object.
-  * @param {String} args.id - ID of the backend object.
-  * @param {String} args.type - QIX type of the backend object. Can for example
-  *                             be "Doc" or "GenericVariable".
-  * @param {String} args.customType - Custom type of the backend object, if defined in qInfo.
-  * @param {Boolean} [args.delta=true] - Flag indicating if delta should be used or not.
-  * @returns {*} Returns the generated and possibly augmented API.
-  */
-  getObjectApi(args) {
-    const { handle, id, type, customType, delta = true } = args;
-    let api = this.apis.getApi(handle);
-    if (api) {
-      return api;
-    }
-    api = this.definition
-    .generate(type)
-    .create(this, handle, id, delta, customType);
-    this.apis.add(handle, api);
-    return api;
-  }
-
-  /**
-  * Function used to determine if it is a primitive patch.
-  * @param  {Array}  patches Patches from engine.
-  * @return {Boolean} Returns true if it is a primitive patch.
-  */
-  isPrimitivePatch(patches) {
-    // It's only `add` and `replace` that has a
-    // value property according to the jsonpatch spec
-    return patches.length === 1 &&
-    ['add', 'replace'].indexOf(patches[0].op) !== -1 &&
-    this.isPrimitiveValue(patches[0].value) &&
-    patches[0].path === '/';
-  }
-
-  /**
-  * Function used to determine if it is a primitive value.
-  * @param  {Any} value.
-  * @return {Boolean} Returns true if it is a primitive value.
-  */
-  isPrimitiveValue(value) {
-    return typeof value !== 'undefined' && value !== null && typeof value !== 'object' && !Array.isArray(value);
-  }
-
-  /**
-  * Function used to get a patchee.
-  * @param {Number} handle - The handle.
-  * @param {Array} patches - The patches.
-  * @param {String} cacheId - The cacheId.
-  * @returns {Object} Returns the patchee.
-  */
-  getPatchee(handle, patches, cacheId) {
-    // handle primitive types, e.g. string, int, bool
-    if (this.isPrimitivePatch(patches)) {
-      const value = patches[0].value;
-      this.apis.setPatchee(handle, cacheId, value);
-      return value;
-    }
-
-    let patchee = this.apis.getPatchee(handle, cacheId);
-
-    if (!this.isPrimitiveValue(patchee)) {
-      patchee = patchee || (patches.length && Array.isArray(patches[0].value) ? [] : {});
-      this.applyPatch(patchee, patches);
-    }
-
-    this.apis.setPatchee(handle, cacheId, patchee);
-
-    return patchee;
-  }
-
-  /**
-  * Function used to apply a patch.
-  * @param {Object} patchee - The object to patch.
-  * @param {Array} patches - The list of patches to apply.
-  */
-  applyPatch(patchee, patches) {
-    this.JSONPatch.apply(patchee, patches);
-  }
-
-  /**
-  * Function used to intercept a request and apply interceptors.
-  * @param {Object} promise - A Promise instance that holds the request to intercept.
-  * @param {Array<Object>} interceptors - Array of objects with onFulfilled
-  *                                       function and onReject function
-  * that will be applied to a request.
-  * @returns {Promise} Returns a promise.
-  */
-  intercept(promise, interceptors, meta) {
-    return interceptors.reduce((interception, interceptor) =>
-      interception.then(
-      interceptor.onFulfilled && interceptor.onFulfilled.bind(this, meta),
-      interceptor.onRejected && interceptor.onRejected.bind(this, meta))
-      , promise
-    );
-  }
-
-  /**
-  * Process error interceptor.
-  * @param {Object} meta - The meta info about the request.
-  * @param response - The response.
-  * @returns {Object} - Returns the defined error for an error, else the response.
-  */
-  processErrorInterceptor(meta, response) {
-    if (typeof response.error !== 'undefined') {
-      this.emit('qix-error', response.error);
-      return this.Promise.reject(response.error);
-    }
-    return response;
-  }
-
-  /**
-  * Process delta interceptor.
-  * @param {Object} meta - The meta info about the request.
-  * @param response - The response.
-  * @returns {Object} - Returns the patched response
-  */
-  processDeltaInterceptor(meta, response) {
-    const result = response.result;
-    if (response.delta) {
-      // when delta is on the response data is expected to be an array of patches
-      const keys = Object.keys(result);
-      for (let i = 0, cnt = keys.length; i < cnt; i += 1) {
-        const key = keys[i];
-        const patches = result[key];
-        if (!Array.isArray(patches)) {
-          return this.Promise.reject('Unexpected rpc response, expected array of patches');
-        }
-        result[key] = this.getPatchee(meta.handle, patches, `${meta.method}-${key}`);
-      }
-      // return a cloned response object to avoid patched object references:
-      return JSON.parse(JSON.stringify(response));
-    }
-    return response;
-  }
-
-  /**
-  * Process result interceptor.
-  * @param {Object} meta - The meta info about the request.
-  * @param response - The response.
-  * @returns {Object} - Returns the result property on the response
-  */
-  processResultInterceptor(meta, response) {
-    return response.result;
-  }
-
-  /**
-  * Processes specific QIX methods that are breaking the protocol specification
-  * and normalizes the response.
-  * @param {Object} meta - The meta info about the request.
-  * @param response - The response.
-  * @returns {Object} - Returns the result property on the response
-  */
-  processMultipleOutParamInterceptor(meta, response) {
-    if (meta.method === 'CreateSessionApp' || meta.method === 'CreateSessionAppFromApp') {
-      // this method returns multiple out params that we need
-      // to normalize before processing the response further:
-      response[RETURN_KEY].qGenericId = response[RETURN_KEY].qGenericId || response.qSessionAppId;
-    } else if (meta.method === 'GetInteract') {
-      // this method returns a qReturn value when it should only return
-      // meta.outKey:
-      delete response[RETURN_KEY];
-    }
-    return response;
-  }
-
-  /**
-  * Process out interceptor.
-  * @param {Object} meta - The meta info about the request.
-  * @param response - The result.
-  * @returns {Object} - Returns the out property on result
-  */
-  processOutInterceptor(meta, response) {
-    if (hasOwnProperty.call(response, RETURN_KEY)) {
-      return response[RETURN_KEY];
-    } else if (meta.outKey !== -1) {
-      return response[meta.outKey];
-    }
-    return response;
-  }
-
-  /**
-  * Function used to process the object API interceptor.
-  * @param {Object} meta - The meta info about the request.
-  * @param response - The response.
-  * @returns {Object} - Returns an object API or the response.
-  */
-  processObjectApiInterceptor(meta, response) {
-    if (response.qHandle && response.qType) {
-      return this.getObjectApi({
-        handle: response.qHandle,
-        type: response.qType,
-        id: response.qGenericId,
-        customType: response.qGenericType,
-        delta: this.delta,
-      });
-    } else if (response.qHandle === null && response.qType === null) {
-      return null;
-    }
-    return response;
   }
 
   /**
@@ -549,20 +119,6 @@ class Session {
       Session.addToPromiseChain(chain, name, value);
       return chain;
     };
-  }
-
-  /**
-  * Function used to build the get method names for Doc APIs.
-  * @param {String} type - The API type.
-  * @returns {String} Returns the get method name, or undefined if the type cannot be restored.
-  */
-  static buildGetMethodName(type) {
-    if (type === 'Field' || type === 'Variable') {
-      return null;
-    } else if (type === 'GenericVariable') {
-      return 'GetVariableById';
-    }
-    return type.replace('Generic', 'Get');
   }
 }
 

--- a/src/session.js
+++ b/src/session.js
@@ -4,6 +4,18 @@ const RPC_CLOSE_NORMAL = 1000;
 const RPC_CLOSE_MANUAL_SUSPEND = 4000;
 
 class Session {
+  /**
+  * Creates a new Session instance.
+  * @param {Object} options The configuration option for this class.
+  * @param {Intercept} options.intercept The intercept instance to use.
+  * @param {ApiCache} options.apis The ApiCache instance to bridge events towards.
+  * @param {Promise} options.Promise The promise constructor to use.
+  * @param {RPC} options.rpc The RPC instance to use when communicating towards Engine.
+  * @param {SuspendResume} options.suspendResume The SuspendResume instance to use.
+  * @param {Object} [options.eventListeners] An object containing keys (event names) and
+  *                                          values (event handlers) that will be bound
+  *                                          during instantiation.
+  */
   constructor(options) {
     const session = this;
     Object.assign(session, options);
@@ -23,6 +35,11 @@ class Session {
     session.emit('session-created', session);
   }
 
+  /**
+  * Event handler for re-triggering error events from RPC.
+  * @emits socket-error
+  * @param {Error} err Webocket error event.
+  */
   onError(err) {
     if (this.suspendResume.isSuspended) {
       return;
@@ -30,6 +47,12 @@ class Session {
     this.emit('socket-error', err);
   }
 
+  /**
+  * Event handler for the RPC close event.
+  * @emits suspended
+  * @emits closed
+  * @param {Event} evt WebSocket close event.
+  */
   onClosed(evt) {
     if (this.suspendResume.isSuspended) {
       return;
@@ -44,6 +67,12 @@ class Session {
     }
   }
 
+  /**
+  * Event handler for the RPC message event.
+  * @emits handle-changed
+  * @emits handle-closed
+  * @param {Object} response JSONRPC response.
+  */
   onMessage(response) {
     if (this.suspendResume.isSuspended) {
       return;
@@ -56,20 +85,43 @@ class Session {
     }
   }
 
+  /**
+  * Event handler for the RPC notification event.
+  * @emits notification:*
+  * @emits notification:[JSONRPC notification name]
+  * @param {Object} response The JSONRPC notification.
+  */
   onNotification(response) {
     this.emit('notification:*', response.method, response.params);
     this.emit(`notification:${response.method}`, response.params);
   }
 
+  /**
+  * Event handler for the RPC traffic event.
+  * @emits traffic:*
+  * @emits traffic:sent
+  * @emits traffic:received
+  * @param {String} dir The traffic direction, sent or received.
+  * @param {Object} JSONRPC request/response/WebSocket message.
+  */
   onTraffic(dir, data) {
     this.emit('traffic:*', dir, data);
     this.emit(`traffic:${dir}`, data);
   }
 
+  /**
+  * Establishes the RPC socket connection.
+  * @returns {Promise} Eventually resolved if the connection was successful.
+  */
   connect() {
     return this.rpc.open();
   }
 
+  /**
+  * Function used to send data on the RPC socket.
+  * @param {Object} request - The request to be sent. (data and some meta info)
+  * @returns {Object} Returns a promise instance.
+  */
   send(request) {
     if (this.suspendResume.isSuspended) {
       return this.Promise.reject(new Error('Session suspended'));
@@ -87,12 +139,23 @@ class Session {
     return promise;
   }
 
+  /**
+  * Suspends the session ("sleeping state"), and closes the RPC connection.
+  * @emits suspended
+  * @param {Promise} Eventually resolved when the RPC connection is closed.
+  */
   suspend() {
     this.suspendResume.suspend();
     return this.rpc.close(RPC_CLOSE_MANUAL_SUSPEND)
       .then(() => this.emit('suspended', { initiator: 'manual' }));
   }
 
+  /**
+  * Resumes a previously suspended session.
+  * @param {Boolean} onlyIfAttached - if true, resume only if the session was re-attached.
+  * @returns {Promise} Eventually resolved if the session was successfully resumed,
+  *                    otherwise rejected.
+  */
   resume(onlyIfAttached) {
     return this.suspendResume.resume(onlyIfAttached).then((value) => {
       this.emit('resumed');
@@ -100,6 +163,10 @@ class Session {
     });
   }
 
+  /**
+  * Function used to close the session.
+  * @returns {Promise} Eventually resolved when the RPC connection is closed.
+  */
   close() {
     return this.rpc.close().then(evt => this.emit('closed', evt));
   }
@@ -108,8 +175,8 @@ class Session {
   * Function used to add info on the promise chain.
   * @private
   * @param {Promise} promise The promise to add info on.
-  * @param {String} name    The property to add info on.
-  * @param {Any} value   The info to add.
+  * @param {String} name The property to add info on.
+  * @param {Any} value The info to add.
   */
   static addToPromiseChain(promise, name, value) {
     promise[name] = value;

--- a/src/session.js
+++ b/src/session.js
@@ -142,11 +142,10 @@ class Session {
   /**
   * Suspends the session ("sleeping state"), and closes the RPC connection.
   * @emits suspended
-  * @param {Promise} Eventually resolved when the RPC connection is closed.
+  * @returns {Promise} Eventually resolved when the RPC connection is closed.
   */
   suspend() {
-    this.suspendResume.suspend();
-    return this.rpc.close(RPC_CLOSE_MANUAL_SUSPEND)
+    return this.suspendResume.suspend()
       .then(() => this.emit('suspended', { initiator: 'manual' }));
   }
 

--- a/src/session.js
+++ b/src/session.js
@@ -61,7 +61,7 @@ class Session {
       return;
     }
     if (this.suspendOnClose) {
-      this.emit('suspended', { initiator: 'network' });
+      this.suspendResume.suspend().then(() => this.emit('suspended', { initiator: 'network' }));
     } else {
       this.emit('closed', evt);
     }

--- a/src/session.js
+++ b/src/session.js
@@ -102,7 +102,7 @@ class Session {
   * @emits traffic:sent
   * @emits traffic:received
   * @param {String} dir The traffic direction, sent or received.
-  * @param {Object} JSONRPC request/response/WebSocket message.
+  * @param {Object} data JSONRPC request/response/WebSocket message.
   */
   onTraffic(dir, data) {
     this.emit('traffic:*', dir, data);

--- a/src/suspend-resume.js
+++ b/src/suspend-resume.js
@@ -1,6 +1,13 @@
 const ON_ATTACHED_TIMEOUT_MS = 5000;
 
 class SuspendResume {
+  /**
+  * Creates a new SuspendResume instance.
+  * @param {Object} options The configuration option for this class.
+  * @param {Promise} options.Promise The promise constructor to use.
+  * @param {RPC} options.rpc The RPC instance to use when communicating towards Engine.
+  * @param {ApiCache} options.apis The ApiCache instance to use.
+  */
   constructor(options) {
     Object.assign(this, options);
     this.isSuspended = false;
@@ -118,10 +125,21 @@ class SuspendResume {
     return Promise.all(tasks);
   }
 
+  /**
+  * Set the instance as suspended.
+  */
   suspend() {
     this.isSuspended = true;
   }
 
+  /**
+  * Resumes a previously suspended RPC connection, and refreshes the API cache.
+  *                                APIs unabled to be restored has their 'closed'
+  *                                event triggered, otherwise 'changed'.
+  * @param {Boolean} onlyIfAttached if true, resume only if the session was re-attached.
+  * @returns {Promise} Eventually resolved if the RPC connection was successfully resumed,
+  *                    otherwise rejected.
+  */
   resume(onlyIfAttached) {
     const changed = [];
     const closed = [];

--- a/src/suspend-resume.js
+++ b/src/suspend-resume.js
@@ -153,9 +153,16 @@ class SuspendResume {
       .then(() => {
         this.isSuspended = false;
         this.apis.clear();
-        changed.forEach(entry => this.apis.add(entry.handle, entry));
-        closed.forEach(api => api.emit('closed'));
-        changed.filter(api => api.type !== 'Global').forEach(api => api.emit('changed'));
+        closed.forEach((api) => {
+          api.emit('closed');
+          api.removeAllListeners();
+        });
+        changed.forEach((api) => {
+          this.apis.add(api.handle, api);
+          if (api.type !== 'Global') {
+            api.emit('changed');
+          }
+        });
       })
       .catch(err => this.rpc.close().then(() => this.Promise.reject(err)));
   }

--- a/src/suspend-resume.js
+++ b/src/suspend-resume.js
@@ -1,0 +1,158 @@
+const ON_ATTACHED_TIMEOUT_MS = 5000;
+
+class SuspendResume {
+  constructor(options) {
+    Object.assign(this, options);
+    this.isSuspended = false;
+    this.rpc.on('traffic', (dir, data) => {
+      if (dir === 'sent' && data.method === 'OpenDoc') {
+        this.openDocParams = data.params;
+      }
+    });
+  }
+
+  /**
+  * Function used to restore the rpc connection.
+  * @param {Boolean} onlyIfAttached - if true, the returned promise will resolve
+  *                                   only if the session can be re-attached.
+  * @returns {Object} Returns a promise instance.
+  */
+  restoreRpcConnection(onlyIfAttached) {
+    return this.rpc.reopen(ON_ATTACHED_TIMEOUT_MS).then((sessionState) => {
+      if (sessionState === 'SESSION_CREATED' && onlyIfAttached) {
+        return this.Promise.reject(new Error('Not attached'));
+      }
+      return this.Promise.resolve();
+    });
+  }
+
+  /**
+  * Function used to restore the global API.
+  * @param {Object} changed - A list where the restored APIs will be added.
+  * @returns {Object} Returns a promise instance.
+  */
+  restoreGlobal(changed) {
+    const global = this.apis.getApisByType('Global').pop();
+    changed.push(global.api);
+    return this.Promise.resolve();
+  }
+
+  /**
+  * Function used to restore the doc API.
+  * @param {String} sessionState - The state of the session, attached or created.
+  * @param {Array} closed - A list where the closed of APIs APIs will be added.
+  * @param {Object} changed - A list where the restored APIs will be added.
+  * @returns {Object} Returns a promise instance.
+  */
+  restoreDoc(closed, changed) {
+    const doc = this.apis.getApisByType('Doc').pop();
+
+    if (!doc) {
+      return this.Promise.resolve();
+    }
+
+    return this.rpc.send({
+      method: 'GetActiveDoc',
+      handle: -1,
+      params: [],
+    }).then((response) => {
+      if (response.error && this.openDocParams) {
+        return this.rpc.send({
+          method: 'OpenDoc',
+          handle: -1,
+          params: this.openDocParams,
+        });
+      }
+      return response;
+    }).then((response) => {
+      if (response.error) {
+        closed.push(doc.api);
+        return this.Promise.resolve();
+      }
+      const handle = response.result.qReturn.qHandle;
+      doc.api.handle = handle;
+      changed.push(doc.api);
+      return this.Promise.resolve(doc.api);
+    });
+  }
+
+  /**
+  * Function used to restore the APIs on the doc.
+  * @param {Object} doc - The doc API on which the APIs we want to restore exist.
+  * @param {Array} closed - A list where the closed of APIs APIs will be added.
+  * @param {Object} changed - A list where the restored APIs will be added.
+  * @returns {Object} Returns a promise instance.
+  */
+  restoreDocObjects(doc, closed, changed) {
+    const tasks = [];
+    const apis = this.apis.getApis()
+        .map(entry => entry.api)
+        .filter(api => api.type !== 'Global' && api.type !== 'Doc');
+
+    if (!doc) {
+      apis.forEach(api => closed.push(api));
+      return this.Promise.resolve();
+    }
+
+    apis.forEach((api) => {
+      const method = SuspendResume.buildGetMethodName(api.type);
+
+      if (!method) {
+        closed.push(api);
+      } else {
+        const request = this.rpc.send({
+          method,
+          handle: doc.handle,
+          params: [api.id],
+        }).then((response) => {
+          if (response.error || !response.result.qReturn.qHandle) {
+            closed.push(api);
+          } else {
+            api.handle = response.result.qReturn.qHandle;
+            changed.push(api);
+          }
+        });
+        tasks.push(request);
+      }
+    });
+    return Promise.all(tasks);
+  }
+
+  suspend() {
+    this.isSuspended = true;
+  }
+
+  resume(onlyIfAttached) {
+    const changed = [];
+    const closed = [];
+
+    return this.restoreRpcConnection(onlyIfAttached)
+      .then(() => this.restoreGlobal(changed))
+      .then(() => this.restoreDoc(closed, changed))
+      .then(doc => this.restoreDocObjects(doc, closed, changed))
+      .then(() => {
+        this.isSuspended = false;
+        this.apis.clear();
+        changed.forEach(entry => this.apis.add(entry.handle, entry));
+        closed.forEach(api => api.emit('closed'));
+        changed.filter(api => api.type !== 'Global').forEach(api => api.emit('changed'));
+      })
+      .catch(err => this.rpc.close().then(() => this.Promise.reject(err)));
+  }
+
+  /**
+  * Function used to build the get method names for Doc APIs.
+  * @param {String} type - The API type.
+  * @returns {String} Returns the get method name, or undefined if the type cannot be restored.
+  */
+  static buildGetMethodName(type) {
+    if (type === 'Field' || type === 'Variable') {
+      return null;
+    } else if (type === 'GenericVariable') {
+      return 'GetVariableById';
+    }
+    return type.replace('Generic', 'Get');
+  }
+}
+
+export default SuspendResume;

--- a/src/suspend-resume.js
+++ b/src/suspend-resume.js
@@ -1,4 +1,5 @@
 const ON_ATTACHED_TIMEOUT_MS = 5000;
+const RPC_CLOSE_MANUAL_SUSPEND = 4000;
 
 class SuspendResume {
   /**
@@ -130,6 +131,7 @@ class SuspendResume {
   */
   suspend() {
     this.isSuspended = true;
+    return this.rpc.close(RPC_CLOSE_MANUAL_SUSPEND);
   }
 
   /**

--- a/test/integration/sugar-mixins.spec.js
+++ b/test/integration/sugar-mixins.spec.js
@@ -97,7 +97,7 @@ describe('Sugar mixins', () => {
         },
       },
     };
-    const appName = 'myAppName';
+    const appName = 'myAppName1';
     const sheetName = 'mySheetName';
 
     return qixGlobal.createApp(appName).then(appInfo =>
@@ -127,7 +127,7 @@ describe('Sugar mixins', () => {
       },
       qSelectionObjectDef: {},
     };
-    const appName = 'myAppName';
+    const appName = 'myAppName2';
     const scriptName = 'ctrl00.txt';
 
     return qixGlobal.createAppAndLoad(appName, scriptName).then((obj) => {
@@ -175,7 +175,7 @@ describe('Sugar mixins', () => {
         qDef: 'sum(Num)',
       },
     };
-    const appName = 'myAppName';
+    const appName = 'myAppName3';
     const scriptName = 'ctrl00.txt';
 
     return qixGlobal.createAppAndLoad(appName, scriptName).then((obj) => {
@@ -208,7 +208,7 @@ describe('Sugar mixins', () => {
         qShowSrcTables: true,
       },
     };
-    const appName = 'myAppName';
+    const appName = 'myAppName4';
     const scriptName = 'ctrl00.txt';
 
     return qixGlobal.createAppAndLoad(appName, scriptName).then((obj) => {
@@ -263,7 +263,7 @@ describe('Sugar mixins', () => {
         tags: [],
       },
     };
-    const appName = 'myAppName';
+    const appName = 'myAppName5';
     const scriptName = 'ctrl00.txt';
 
     return qixGlobal.createAppAndLoad(appName, scriptName).then((obj) => {
@@ -306,7 +306,7 @@ describe('Sugar mixins', () => {
       qComment: '',
       qDefinition: 'Month',
     };
-    const appName = 'myAppName';
+    const appName = 'myAppName6';
     const scriptName = 'ctrl00.txt';
 
     return qixGlobal.createAppAndLoad(appName, scriptName).then((obj) => {

--- a/test/integration/traffic.spec.js
+++ b/test/integration/traffic.spec.js
@@ -41,29 +41,28 @@ describe('qix-logging', () => {
     return qixGlobal.session.close();
   });
 
-  it('should log qix traffic', () => {
-    qixGlobal.allowCreateApp().then(() => {
-      const request = {
-        method: 'AllowCreateApp',
-        handle: -1,
-        params: [],
-        delta: false,
-        outKey: -1,
-        id: 1,
-      };
-      const response = {
-        id: 1,
-        jsonrpc: '2.0',
-        result: {
-          qReturn: true,
-        },
-      };
-      expect(config.listeners['traffic:sent'].firstCall.args[0]).to.containSubset(request);
-      expect(config.listeners['traffic:received'].firstCall.args[0]).to.containSubset(response);
-      expect(config.listeners['traffic:*'].firstCall.args[0]).to.equal('sent');
-      expect(config.listeners['traffic:*'].firstCall.args[1]).to.containSubset(request);
-      expect(config.listeners['traffic:*'].secondCall.args[0]).to.equal('received');
-      expect(config.listeners['traffic:*'].secondCall.args[1]).to.containSubset(response);
-    });
-  });
+  it('should log qix traffic', () => Promise.delay(100).then(() => qixGlobal.allowCreateApp().then(() => {
+    const request = {
+      method: 'AllowCreateApp',
+      handle: -1,
+      params: [],
+      delta: false,
+      id: 1,
+    };
+    const response = {
+      id: 1,
+      jsonrpc: '2.0',
+      result: {
+        qReturn: true,
+      },
+    };
+    // we have traffic:received for OnConnected notification before (so second received
+    // msg should be ours):
+    expect(config.listeners['traffic:sent'].firstCall.args[0]).to.containSubset(request);
+    expect(config.listeners['traffic:received'].secondCall.args[0]).to.containSubset(response);
+    expect(config.listeners['traffic:*'].secondCall.args[0]).to.equal('sent');
+    expect(config.listeners['traffic:*'].secondCall.args[1]).to.containSubset(request);
+    expect(config.listeners['traffic:*'].thirdCall.args[0]).to.equal('received');
+    expect(config.listeners['traffic:*'].thirdCall.args[1]).to.containSubset(response);
+  })));
 });

--- a/test/unit/api-cache.spec.js
+++ b/test/unit/api-cache.spec.js
@@ -1,0 +1,135 @@
+import ApiCache from '../../src/api-cache';
+
+describe('ApiCache', () => {
+  let apiCache;
+  let schema;
+
+  beforeEach(() => {
+    schema = {
+      generate: sinon.stub().returnsThis(),
+      create: sinon.stub().returnsArg(1),
+    };
+    apiCache = new ApiCache({ schema });
+    apiCache.session = {};
+  });
+
+  it('should be a constructor', () => {
+    expect(ApiCache).to.be.a('function');
+    expect(ApiCache).to.throw();
+  });
+
+  it('should add an api', () => {
+    const api = {};
+    const entry = apiCache.add(1, api);
+    expect(apiCache.entries['1']).to.equal(entry);
+  });
+
+  it('should get an api', () => {
+    const api = {};
+    apiCache.add(1, api);
+    expect(apiCache.getApi(1)).to.equal(api);
+  });
+
+  it('should return an undefined api if an api is not found', () => {
+    const api = {};
+    apiCache.add(1, api);
+    expect(apiCache.getApi(2)).to.equal(undefined);
+  });
+
+  it('should return an undefined api if given an undefined handle', () => {
+    const api = {};
+    apiCache.add(1, api);
+    expect(apiCache.getApi(undefined)).to.equal(undefined);
+  });
+
+  it('should get all api entries', () => {
+    apiCache.add('1', 'foo');
+    apiCache.add('2', 'bar');
+
+    const entries = apiCache.getApis();
+    expect(entries).to.be.an('Array');
+    expect(entries.length).to.equal(2);
+    expect(entries[1]).to.deep.equal({ handle: '2', api: 'bar' });
+  });
+
+  it('should get a patchee', () => {
+    const api = {};
+    const patchee = {};
+    apiCache.add(1, api);
+    apiCache.addPatchee(1, 'method', patchee);
+    expect(apiCache.getPatchee(1, 'method')).to.equal(patchee);
+  });
+
+  it('should add a patchee', () => {
+    const api = {};
+    const patchee = {};
+    const entry = apiCache.add(1, api);
+    apiCache.addPatchee(1, 'method', patchee);
+    expect(entry.deltaCache.entries.method).to.equal(patchee);
+  });
+
+
+  it('should emit changed on handle changed', () => {
+    const api = {
+      emit: sinon.spy(),
+    };
+    apiCache.add(10, api);
+    apiCache.onHandleChanged(10);
+    expect(api.emit).to.have.been.calledWith('changed');
+  });
+
+  it('should emit closed on handle closed', () => {
+    const api = {
+      emit: sinon.spy(),
+      removeAllListeners: () => {},
+    };
+    apiCache.add(10, api);
+    apiCache.onHandleClosed(10);
+    expect(api.emit).to.have.been.calledWith('closed');
+  });
+
+  it('should remove api on handle closed', () => {
+    const api = {
+      emit: sinon.spy(),
+      removeAllListeners: () => {},
+    };
+    const remove = sinon.spy(apiCache, 'remove');
+    apiCache.add(10, api);
+    apiCache.onHandleClosed(10);
+    expect(remove).to.have.been.calledWith(10);
+  });
+
+  it('should not try to remove unexisting api on handle closed', () => {
+    const remove = sinon.spy(apiCache, 'remove');
+    apiCache.onHandleClosed(10);
+    expect(remove.callCount).to.equal(0);
+  });
+
+  it('should emit closed on close', () => {
+    const api2 = {
+      emit: sinon.spy(),
+      removeAllListeners: () => {},
+    };
+    apiCache.add(20, api2);
+    apiCache.onSessionClosed();
+    expect(api2.emit).to.have.been.calledWith('closed');
+    expect(apiCache.getAll().length).to.be.equal(0);
+  });
+
+  describe('getObjectApi', () => {
+    it('should get an existing api', () => {
+      const typeDef = {
+        Foo: { In: [], Out: [] },
+      };
+      apiCache.add(-1, typeDef);
+      const api = apiCache.getObjectApi({ handle: -1, id: 'id_1234', type: 'Foo', customType: 'Bar', delta: false });
+      expect(api).to.equal(typeDef);
+    });
+
+    it('should create and return an api', () => {
+      apiCache.getObjectApi({ handle: -1, id: 'id_1234', type: 'Foo', customType: 'Bar' });
+      expect(schema.generate).to.be.calledWith('Foo');
+      expect(schema.create).to.be.calledWith(apiCache.session, -1, 'id_1234', true, 'Bar');
+    });
+  });
+});

--- a/test/unit/cache.spec.js
+++ b/test/unit/cache.spec.js
@@ -1,133 +1,59 @@
 import KeyValueCache from '../../src/cache';
-import ApiCache from '../../src/api-cache';
 
-describe('Cache', () => {
-  describe('KeyValueCache', () => {
-    let keyValueCache;
+describe('KeyValueCache', () => {
+  let keyValueCache;
 
-    beforeEach(() => {
-      keyValueCache = new KeyValueCache();
-    });
-
-    it('should be a constructor', () => {
-      expect(KeyValueCache).to.be.a('function');
-      expect(KeyValueCache).to.throw();
-    });
-
-    it('should set instance variables', () => {
-      expect(keyValueCache.entries).to.be.an('object');
-    });
-
-    it('should add an entry', () => {
-      keyValueCache.add('foo', 'bar');
-      expect(keyValueCache.entries.foo).to.equal('bar');
-      expect(keyValueCache.add.bind(keyValueCache, 'foo')).to.throw();
-    });
-
-    it('should remove an entry', () => {
-      keyValueCache.add('foo', 'bar');
-      expect(keyValueCache.entries.foo).to.equal('bar');
-      keyValueCache.remove('foo');
-      expect(Object.prototype.hasOwnProperty.call(keyValueCache.entries, 'foo')).to.equal(false);
-    });
-
-    it('should get an entry', () => {
-      keyValueCache.add('foo', 'bar');
-      expect(keyValueCache.get('foo')).to.equal('bar');
-    });
-
-    it('should find the key for entry', () => {
-      keyValueCache.add('foo', 'bar');
-      expect(keyValueCache.getKey('bar')).to.equal('foo');
-    });
-
-    it('should get all entries', () => {
-      keyValueCache.add('foo1', 'bar1');
-      keyValueCache.add('foo2', 'bar2');
-
-      const entries = keyValueCache.getAll();
-      expect(entries).to.be.an('Array');
-      expect(entries.length).to.equal(2);
-      expect(entries[0]).to.deep.equal({ key: 'foo1', value: 'bar1' });
-    });
-
-    it('should clear all entries', () => {
-      keyValueCache.add('foo', 'bar');
-      keyValueCache.add('foo1', 'bar1');
-      expect(Object.keys(keyValueCache.entries)).to.have.length(2);
-      keyValueCache.clear();
-      expect(Object.keys(keyValueCache.entries)).to.have.length(0);
-    });
+  beforeEach(() => {
+    keyValueCache = new KeyValueCache();
   });
 
-  describe('ApiCache', () => {
-    let apiCache;
+  it('should be a constructor', () => {
+    expect(KeyValueCache).to.be.a('function');
+    expect(KeyValueCache).to.throw();
+  });
 
-    beforeEach(() => {
-      apiCache = new ApiCache();
-    });
+  it('should set instance variables', () => {
+    expect(keyValueCache.entries).to.be.an('object');
+  });
 
-    it('should be a constructor', () => {
-      expect(ApiCache).to.be.a('function');
-      expect(ApiCache).to.throw();
-    });
+  it('should add an entry', () => {
+    keyValueCache.add('foo', 'bar');
+    expect(keyValueCache.entries.foo).to.equal('bar');
+    expect(keyValueCache.add.bind(keyValueCache, 'foo')).to.throw();
+  });
 
-    it('should be able to pre-populate the cache', () => {
-      const apis = [{ handle: '0', value: 'foo' }, { handle: '1', value: 'bar' }];
-      apiCache = new ApiCache(apis);
-      expect(apiCache.getApis().length).to.equal(2);
-      expect(apiCache.entries['0'].api).to.deep.equal(apis[0]);
-      expect(apiCache.entries['1'].api).to.deep.equal(apis[1]);
-    });
+  it('should remove an entry', () => {
+    keyValueCache.add('foo', 'bar');
+    expect(keyValueCache.entries.foo).to.equal('bar');
+    keyValueCache.remove('foo');
+    expect(Object.prototype.hasOwnProperty.call(keyValueCache.entries, 'foo')).to.equal(false);
+  });
 
-    it('should add an api', () => {
-      const api = {};
-      const entry = apiCache.add(1, api);
-      expect(apiCache.entries['1']).to.equal(entry);
-    });
+  it('should get an entry', () => {
+    keyValueCache.add('foo', 'bar');
+    expect(keyValueCache.get('foo')).to.equal('bar');
+  });
 
-    it('should get an api', () => {
-      const api = {};
-      apiCache.add(1, api);
-      expect(apiCache.getApi(1)).to.equal(api);
-    });
+  it('should find the key for entry', () => {
+    keyValueCache.add('foo', 'bar');
+    expect(keyValueCache.getKey('bar')).to.equal('foo');
+  });
 
-    it('should return an undefined api if an api is not found', () => {
-      const api = {};
-      apiCache.add(1, api);
-      expect(apiCache.getApi(2)).to.equal(undefined);
-    });
+  it('should get all entries', () => {
+    keyValueCache.add('foo1', 'bar1');
+    keyValueCache.add('foo2', 'bar2');
 
-    it('should return an undefined api if given an undefined handle', () => {
-      const api = {};
-      apiCache.add(1, api);
-      expect(apiCache.getApi(undefined)).to.equal(undefined);
-    });
+    const entries = keyValueCache.getAll();
+    expect(entries).to.be.an('Array');
+    expect(entries.length).to.equal(2);
+    expect(entries[0]).to.deep.equal({ key: 'foo1', value: 'bar1' });
+  });
 
-    it('should get all api entries', () => {
-      apiCache.add('1', 'foo');
-      apiCache.add('2', 'bar');
-
-      const entries = apiCache.getApis();
-      expect(entries).to.be.an('Array');
-      expect(entries.length).to.equal(2);
-      expect(entries[1]).to.deep.equal({ handle: '2', api: 'bar' });
-    });
-
-    it('should get a patchee', () => {
-      const api = {};
-      const patchee = {};
-      apiCache.add(1, api);
-      apiCache.addPatchee(1, 'method', patchee);
-      expect(apiCache.getPatchee(1, 'method')).to.equal(patchee);
-    });
-
-    it('should add a patchee', () => {
-      const api = {};
-      const patchee = {};
-      const entry = apiCache.add(1, api);
-      apiCache.addPatchee(1, 'method', patchee);
-      expect(entry.deltaCache.entries.method).to.equal(patchee);
-    });
+  it('should clear all entries', () => {
+    keyValueCache.add('foo', 'bar');
+    keyValueCache.add('foo1', 'bar1');
+    expect(Object.keys(keyValueCache.entries)).to.have.length(2);
+    keyValueCache.clear();
+    expect(Object.keys(keyValueCache.entries)).to.have.length(0);
   });
 });

--- a/test/unit/intercept.spec.js
+++ b/test/unit/intercept.spec.js
@@ -1,0 +1,222 @@
+import Promise from 'bluebird';
+import Intercept from '../../src/intercept';
+import ApiCache from '../../src/api-cache';
+
+describe('Intercept', () => {
+  let JSONPatch;
+  let intercept;
+  let schema;
+  let apis;
+
+  beforeEach(() => {
+    schema = {
+      generate: sinon.stub().returnsThis(),
+      create: sinon.stub().returnsArg(1),
+    };
+    JSONPatch = { apply() {} };
+    apis = new ApiCache({ schema });
+    intercept = new Intercept({ Promise, JSONPatch, apis, delta: true });
+  });
+
+  describe('getPatchee', () => {
+    it('should get an existing patchee', () => {
+      const patchee = {};
+      apis.add(-1, {});
+      apis.addPatchee(-1, 'Foo', patchee);
+      expect(intercept.getPatchee(-1, [], 'Foo')).to.equal(patchee);
+      expect(intercept.getPatchee(-1, [], 'Foo')).to.equal(patchee);
+    });
+
+    it('should apply and return a patchee', () => {
+      const JSONPatchStub = sinon.stub(JSONPatch, 'apply');
+      apis.add(-1, {});
+      apis.addPatchee(-1, 'Foo', {});
+      intercept.getPatchee(-1, [{ op: 'add', path: '/', value: {} }], 'Foo');
+      expect(JSONPatchStub).to.have.been.calledWith({}, [{ op: 'add', path: '/', value: {} }]);
+
+      JSONPatchStub.reset();
+
+      apis.addPatchee(-1, 'Bar', []);
+      intercept.getPatchee(-1, [{ op: 'add', path: '/', value: [] }], 'Bar');
+      expect(JSONPatchStub).to.have.been.calledWith([], [{ op: 'add', path: '/', value: [] }]);
+
+      JSONPatchStub.reset();
+
+    // primitive
+      apis.addPatchee(-1, 'Baz', 'my folder');
+      intercept.getPatchee(-1, [{ op: 'add', path: '/', value: ['my documents'] }], 'Baz');
+      expect(JSONPatchStub.callCount).to.equal(0);
+    });
+
+    describe('primitive patch', () => {
+      let value;
+
+      beforeEach(() => {
+        apis.add(-1, {});
+      });
+
+      describe('add', () => {
+        const op = 'add';
+
+        it('should return a string', () => {
+          value = intercept.getPatchee(-1, [{ op, path: '/', value: 'A string' }], 'Foo');
+          expect(value).to.equal('A string');
+        });
+
+        it('should return a boolean', () => {
+          value = intercept.getPatchee(-1, [{ op, path: '/', value: true }], 'Foo');
+          expect(value).to.equal(true);
+        });
+
+        it('should return a number', () => {
+          value = intercept.getPatchee(-1, [{ op, path: '/', value: 123 }], 'Foo');
+          expect(value).to.equal(123);
+        });
+      });
+
+      describe('replace', () => {
+        const op = 'replace';
+
+        it('should return a string', () => {
+          value = intercept.getPatchee(-1, [{ op, path: '/', value: 'A string' }], 'Foo');
+          expect(value).to.equal('A string');
+        });
+
+        it('should return a boolean', () => {
+          value = intercept.getPatchee(-1, [{ op, path: '/', value: true }], 'Foo');
+          expect(value).to.equal(true);
+        });
+
+        it('should return a number', () => {
+          value = intercept.getPatchee(-1, [{ op, path: '/', value: 123 }], 'Foo');
+          expect(value).to.equal(123);
+        });
+      });
+
+      it('should cache primitive patches', () => {
+        value = intercept.getPatchee(-1, [{ op: 'add', path: '/', value: 'A string' }], 'Foo');
+        expect(value).to.equal('A string');
+        expect(intercept.getPatchee(-1, [], 'Foo')).to.equal(value);
+      });
+
+      it('should not throw if primitive patch already exists', () => {
+        intercept.getPatchee(-1, [{ op: 'add', path: '/', value: 'A string' }], 'Foo');
+        expect(intercept.getPatchee(-1, [{ op: 'replace', path: '/', value: 'Bar' }], 'Foo')).to.equal('Bar');
+      });
+    });
+  });
+
+  describe('intercept', () => {
+    it('should call interceptors onFulfilled', () => {
+      intercept.interceptors = [{ onFulfilled: sinon.stub().returns({ bar: {} }) }];
+      return expect(intercept.execute(Promise.resolve({ foo: {} })))
+        .to.eventually.deep.equal({ bar: {} });
+    });
+
+    it('should reject and stop the interceptor chain', () => {
+      const spyFulFilled = sinon.spy();
+      intercept.interceptors = [{ onFulfilled() { return Promise.reject('foo'); } }, { onFulfilled: spyFulFilled }];
+      return expect(intercept.execute(Promise.resolve()).then(() => {}, (err) => {
+        expect(spyFulFilled.callCount).to.equal(0);
+        return Promise.reject(err);
+      })).to.eventually.be.rejectedWith('foo');
+    });
+
+    it('should call interceptors onRejected', () => {
+      const onRejected = sinon.stub().returns('foo');
+      intercept.interceptors = [{ onFulfilled() { return Promise.reject('foo'); } }, { onFulfilled() {}, onRejected }];
+      return expect(intercept.execute(Promise.resolve(), {})).to.eventually.equal('foo');
+    });
+  });
+
+  describe('processErrorInterceptor', () => {
+    it('should reject and emit if the response contains an error', () => intercept.processErrorInterceptor({}, { error: 'FUBAR' }).then(null, (err) => {
+      expect(err).to.equal('FUBAR');
+    }));
+
+    it('should not reject if the response does not contain any error', () => {
+      const response = {};
+      expect(intercept.processErrorInterceptor({}, response)).to.equal(response);
+    });
+  });
+
+  describe('processDeltaInterceptor', () => {
+    let response = { result: { foo: {} } };
+
+    it('should call getPatchee', () => {
+      response = { result: { qReturn: [{ foo: {} }] }, delta: true };
+      const stub = sinon.stub(intercept, 'getPatchee').returns(response.result.qReturn);
+      intercept.processDeltaInterceptor({ handle: 1, method: 'Foo', outKey: -1 }, response);
+      expect(stub).to.have.been.calledWith(1, response.result.qReturn, 'Foo-qReturn');
+    });
+
+    it('should reject when response is not an array of patches', () => {
+      response = { result: { qReturn: { foo: {} } }, delta: true };
+      return expect(intercept.processDeltaInterceptor({ handle: 1, method: 'Foo', outKey: -1 }, response)).to.eventually.be.rejectedWith('Unexpected rpc response, expected array of patches');
+    });
+
+    it('should return response if delta is falsy', () => {
+      response = { result: { qReturn: [{ foo: {} }] }, delta: false };
+      expect(intercept.processDeltaInterceptor({ handle: 1, method: 'Foo', outKey: -1 }, response)).to.equal(response);
+    });
+  });
+
+  describe('processResultInterceptor', () => {
+    const response = { result: { foo: {} } };
+
+    it('should return result', () => {
+      expect(intercept.processResultInterceptor({ outKey: -1 }, response))
+        .to.be.equal(response.result);
+    });
+  });
+
+  describe('processMultipleOutParamInterceptor', () => {
+    it('should append missing qGenericId for CreateSessionApp', () => {
+      const result = { qReturn: { qHandle: 1, qType: 'Doc' }, qSessionAppId: 'test' };
+      const out = intercept.processMultipleOutParamInterceptor({ method: 'CreateSessionApp' }, result);
+      expect(out.qReturn.qGenericId).to.be.equal(result.qSessionAppId);
+    });
+
+    it('should remove errenous qReturn from GetInteract', () => {
+      const result = { qReturn: false, qDef: 'test' };
+      const out = intercept.processMultipleOutParamInterceptor({ method: 'GetInteract' }, result);
+      expect(out.qReturn).to.be.equal(undefined);
+    });
+  });
+
+  describe('processOutInterceptor', () => {
+    it('should return result with out key', () => {
+      const result = { foo: { bar: {} } };
+      expect(intercept.processOutInterceptor({ outKey: 'foo' }, result)).to.be.equal(result.foo);
+    });
+
+    it('should return result with return key', () => {
+      const result = { qReturn: { foo: {} } };
+      expect(intercept.processOutInterceptor({ outKey: -1 }, result)).to.be.equal(result.qReturn);
+    });
+
+    it('should return result if neither out key or return key is specified', () => {
+      const result = { foo: {} };
+      expect(intercept.processOutInterceptor({ outKey: -1 }, result)).to.be.equal(result);
+    });
+  });
+
+  describe('processObjectApiInterceptor', () => {
+    it('should call getObjectApi', () => {
+      const response = { qHandle: 1, qType: 'Foo', qGenericId: 'Baz', qGenericType: 'Bar' };
+      const stub = sinon.stub(apis, 'getObjectApi');
+      intercept.processObjectApiInterceptor({}, response);
+      expect(stub).to.have.been.calledWith({ handle: 1, type: 'Foo', id: 'Baz', customType: 'Bar', delta: true });
+    });
+
+    it("should return null if requested object doesn't exist", () => {
+      const response = { qHandle: null, qType: null };
+      return expect(intercept.processObjectApiInterceptor({}, response)).to.equal(null);
+    });
+
+    it('should return response argument if qHandle/qType are undefined', () => {
+      const response = {};
+      return expect(intercept.processObjectApiInterceptor({}, response)).to.equal(response);
+    });
+  });
+});

--- a/test/unit/qix.spec.js
+++ b/test/unit/qix.spec.js
@@ -138,7 +138,7 @@ describe('Qix', () => {
       session = {
         connect: sinon.stub().returns(Promise.resolve()),
         send: sinon.stub().returns(Promise.resolve()),
-        getObjectApi: sinon.stub().returns(stubApi),
+        apis: { getObjectApi: sinon.stub().returns(stubApi) },
       };
       sandbox.stub(Qix, 'getSession').returns(session);
 
@@ -148,7 +148,7 @@ describe('Qix', () => {
     });
 
     it('should get global', () => {
-      expect(session.getObjectApi).to.have.been.calledWith({ handle: -1, id: 'Global', type: 'Global', customType: 'Global', delta: undefined });
+      expect(session.apis.getObjectApi).to.have.been.calledWith({ handle: -1, id: 'Global', type: 'Global', customType: 'Global', delta: undefined });
       expect(globalApi).to.deep.equal(stubApi);
     });
 

--- a/test/unit/rpc.spec.js
+++ b/test/unit/rpc.spec.js
@@ -8,7 +8,7 @@ describe('RPC', () => {
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    rpc = new RPC(Promise, 'http://localhost:4848', url => new SocketMock(url), true);
+    rpc = new RPC({ Promise, url: 'http://localhost:4848', createSocket: url => new SocketMock(url, false) });
   });
 
   afterEach(() => {
@@ -46,9 +46,8 @@ describe('RPC', () => {
   it('should call createSocket when open is called', () => {
     const createSocket = sandbox.spy(rpc, 'createSocket');
     rpc.url = 'foo';
-    rpc.sessionConfig = { bar: 'baz' };
     rpc.open();
-    expect(createSocket).to.have.been.calledWithExactly(rpc.url, rpc.sessionConfig);
+    expect(createSocket).to.have.been.calledWithExactly(rpc.url);
   });
 
   it('should return SESSION_CREATED when reopen hits the timeout', () => {

--- a/test/unit/session.spec.js
+++ b/test/unit/session.spec.js
@@ -1,28 +1,27 @@
 import Promise from 'bluebird';
 import Session from '../../src/session';
-import RPC from '../../src/rpc';
 import RPCMock from '../mocks/rpc-mock';
 import SocketMock from '../mocks/socket-mock';
-import ApiCache from '../../src/api-cache';
 
 describe('Session', () => {
   let session;
   let sandbox;
-  const definition = {
-    generate: sinon.stub().returnsThis(),
-    create: sinon.stub().returnsArg(1),
-  };
-  const JSONPatchMock = { apply() {} };
+  const suspendResume = {};
+  const apis = {};
+  const intercept = { execute: () => Promise.resolve() };
   const createSession = (throwError, rpc, listeners) => {
-    session = new Session(
-      rpc || new RPCMock(Promise, 'http://localhost:4848', url =>
-      new SocketMock(url, throwError)
-    ),
-    true,
-    definition,
-    JSONPatchMock,
-    Promise,
-    listeners);
+    session = new Session({
+      Promise,
+      eventListeners: listeners,
+      apis,
+      suspendResume,
+      intercept,
+      rpc: rpc || new RPCMock({
+        Promise,
+        url: 'http://localhost:4848',
+        createSocket: url => new SocketMock(url, throwError),
+      }),
+    });
   };
 
   beforeEach(() => {
@@ -37,15 +36,6 @@ describe('Session', () => {
   it('should be a constructor', () => {
     expect(Session).to.be.a('function');
     expect(Session).to.throw();
-  });
-
-  it('should set instance variables', () => {
-    expect(session.rpc).to.be.an.instanceOf(RPCMock);
-    expect(session.delta).to.equal(true);
-    expect(session.apis).to.be.an.instanceOf(ApiCache);
-    expect(session.JSONPatch).to.equal(JSONPatchMock);
-    expect(session.Promise).to.equal(Promise);
-    expect(session.definition).to.equal(definition);
   });
 
   it('should return a promise when connect is called', () => {
@@ -89,7 +79,6 @@ describe('Session', () => {
         return Promise.resolve(data);
       });
 
-      sandbox.stub(session, 'intercept').returns(Promise.resolve({}));
       const fn = sandbox.stub(Session, 'addToPromiseChain');
       const request = {};
       return session.send(request).then(() => {
@@ -107,138 +96,11 @@ describe('Session', () => {
       const rpc = new RPCMock(Promise, SocketMock, 'http://localhost:4848', {});
       createSession(false, rpc);
 
-      sandbox.stub(session, 'intercept').returns(Promise.resolve({}));
       const send = sinon.spy(rpc, 'send');
 
       session.send({ method: 'a', handle: 1, params: [], delta: true, xyz: 'xyz' });
       expect(send).to.have.been.calledWithExactly({ method: 'a', handle: 1, params: [], delta: true });
       expect(send).to.have.been.calledWithExactly(sinon.match(isValid));
-    });
-  });
-
-  describe('Suspend', () => {
-    beforeEach(() => {
-      SocketMock.on('created', socket => socket.open());
-    });
-
-    afterEach(() => {
-      SocketMock.removeAllListeners('created');
-    });
-
-    it('should close rpc and set suspended flag on call to suspend()', () => {
-      const rpcClose = sinon.spy(session.rpc, 'close');
-      return session.connect().then(() => session.suspend()).then(() => {
-        expect(rpcClose.calledOnce).to.equal(true);
-        expect(session.suspended).to.equal(true);
-      });
-    });
-
-    it('should emit the suspended event when suspended', () => {
-      const emit = sinon.spy(session, 'emit');
-      return session.connect().then(() => session.suspend()).then(() => {
-        expect(emit).to.have.been.calledWith('suspended', { initiator: 'manual' });
-      });
-    });
-
-    it('should suspend on unexpected rpc close when suspendOnClose is true', () => {
-      session.suspendOnClose = true;
-      const emit = sinon.spy(session, 'emit');
-      return session.connect().then(() => session.rpc.close(1006)).then(() => {
-        expect(session.suspended).to.equal(true);
-        expect(emit).to.have.been.calledWith('suspended', { initiator: 'network' });
-      });
-    });
-
-    it('should close on unexpected rpc close when suspendOnClose is false', () => {
-      const emit = sinon.spy(session, 'emit');
-      return session.connect().then(() => session.rpc.close(1006)).then(() => {
-        expect(session.suspended).to.equal(false);
-        expect(emit).to.have.been.calledWith('closed');
-      });
-    });
-  });
-
-  describe('Resume', () => {
-    beforeEach(() => {
-      SocketMock.on('created', socket => socket.open());
-      class Dummy extends RPC { reopen() { return super.reopen(5); } }
-      const rpc = new Dummy(Promise, 'http://localhost:4848', url => new SocketMock(url, false));
-      createSession(false, rpc);
-    });
-
-    afterEach(() => {
-      SocketMock.removeAllListeners('created');
-    });
-
-    it('should reject created sessions when onlyIfAttached is true', () => {
-      const p = session.connect().then(() => session.suspend()).then(() => session.resume(true));
-      expect(p).to.eventually.be.rejectedWith('Not attached');
-    });
-
-    it('should restore global', () => {
-      const apis = new ApiCache();
-      apis.add(-1, { emit: sinon.stub(), handle: -1, type: 'Global' });
-      return session.resume().then(() => expect(apis.getApi(-1).emit.notCalled).to.equal(true));
-    });
-
-    it('should close doc', () => {
-      const apisToClose = [
-        { emit: sinon.stub(), handle: 1, type: 'Doc', id: 1 },
-        { emit: sinon.stub(), handle: 2, type: 'GenericObject', id: 2 },
-      ];
-
-      const apis = new ApiCache(apisToClose);
-      apis.add(-1, { emit: sinon.stub(), handle: -1, type: 'Global' });
-
-      SocketMock.on('created', (socket) => {
-        socket.intercept('GetActiveDoc').return({ error: { message: 'Oh, no!' } });
-        socket.intercept('OpenDoc').return({ error: { message: 'Oh, no!' } });
-      });
-
-      session.apis = apis;
-      session.suspended = true;
-
-      return session.resume(false).then(() => {
-        expect(session.apis.getApis().length).to.equal(1);
-        apisToClose.forEach(api => expect(api.emit).to.have.been.calledWith('closed'));
-      });
-    });
-
-    it('should restore doc and objects', () => {
-      const apisToChange = [
-        { emit: sinon.stub(), handle: 1, type: 'Doc', id: 1 },
-        { emit: sinon.stub(), handle: 2, type: 'GenericObject', id: 2 },
-        { emit: sinon.stub(), handle: 3, type: 'GenericVariable', id: 3 },
-      ];
-      const apisToClose = [
-        { emit: sinon.stub(), handle: 4, type: 'Field', id: 4 },
-        { emit: sinon.stub(), handle: 5, type: 'GenericDummy', id: 5 },
-        { emit: sinon.stub(), handle: 6, type: 'GenericBookmark', id: 6 },
-      ];
-
-      const apis = new ApiCache(apisToChange.concat(apisToClose));
-      apis.add(-1, { emit: sinon.stub(), handle: -1, type: 'Global' });
-
-      SocketMock.on('created', (socket) => {
-        socket.intercept('GetActiveDoc').return({ result: { qReturn: { qHandle: 101 } } });
-        socket.intercept('GetObject').return({ result: { qReturn: { qHandle: 102 } } });
-        socket.intercept('GetVariableById').return({ result: { qReturn: { qHandle: 103 } } });
-        socket.intercept('GetDummy').return({ error: {} });
-        socket.intercept('GetBookmark').return({ result: { qReturn: { qHandle: null } } });
-      });
-
-      session.apis = apis;
-      session.suspended = true;
-
-      return session.resume(true).catch(() => {
-        apisToChange.forEach(api => expect(api.emit.notCalled).to.equal(true));
-        apisToClose.forEach(api => expect(api.emit.notCalled).to.equal(true));
-        expect(session.apis).to.deep.equal(apis);
-      }).then(() => session.resume(false)).then(() => {
-        expect(session.apis.getApis().length).to.equal(4);
-        apisToChange.forEach(api => expect(api.emit).to.have.been.calledWith('changed'));
-        apisToClose.forEach(api => expect(api.emit).to.have.been.calledWith('closed'));
-      });
     });
   });
 
@@ -294,289 +156,15 @@ describe('Session', () => {
     expect(emit).to.have.been.calledWith('socket-error', 'fubar');
   });
 
-  it('should emit changed on handle changed', () => {
-    const api = {
-      emit: sinon.spy(),
-    };
-    session.apis.add(10, api);
-    session.emit('handle-changed', 10);
-    expect(api.emit).to.have.been.calledWith('changed');
-  });
-
-  it("should not emit changed on handle changed if there isn't an api", () => {
-    const api = {
-      emit: sinon.spy(),
-    };
-    session.emit('handle-changed', 10);
-    expect(api.emit.callCount).to.equal(0);
-  });
-
-  it('should emit closed on handle closed', () => {
-    const api = {
-      emit: sinon.spy(),
-      removeAllListeners: () => {},
-    };
-    session.apis.add(10, api);
-    session.emit('handle-closed', 10);
-    expect(api.emit).to.have.been.calledWith('closed');
-  });
-
-  it('should remove api on handle closed', () => {
-    const api = {
-      emit: sinon.spy(),
-      removeAllListeners: () => {},
-    };
-    const remove = sinon.spy(session.apis, 'remove');
-    session.apis.add(10, api);
-    session.emit('handle-closed', 10);
-    expect(remove).to.have.been.calledWith(10);
-  });
-
-  it('should not try to remove unexisting api on handle closed', () => {
-    const remove = sinon.spy(session.apis, 'remove');
-    session.emit('handle-closed', 10);
-    expect(remove.callCount).to.equal(0);
-  });
-
-  it('should emit closed on close', () => {
-    const api2 = {
-      emit: sinon.spy(),
-      removeAllListeners: () => {},
-    };
-    session.apis.add(20, api2);
-    session.emit('closed');
-    expect(api2.emit).to.have.been.calledWith('closed');
-    expect(session.apis.getAll().length).to.be.equal(0);
-  });
 
   it('should close', () => {
-    const rpc = new RPCMock(Promise, 'http://localhost:4848', url => new SocketMock(url));
+    const rpc = new RPCMock({ Promise, url: 'http://localhost:4848', createSocket: url => new SocketMock(url) });
     createSession(false, rpc);
     session.connect();
     const close = sinon.spy(rpc, 'close');
     const closePromise = session.close();
     expect(closePromise).to.be.an.instanceOf(Promise);
     expect(close.calledOnce).to.equal(true);
-  });
-
-  describe('getObjectApi', () => {
-    it('should get an existing api', () => {
-      const typeDef = {
-        Foo: { In: [], Out: [] },
-      };
-      session.apis.add(-1, typeDef);
-      const api = session.getObjectApi({ handle: -1, id: 'id_1234', type: 'Foo', customType: 'Bar', delta: false });
-      expect(api).to.equal(typeDef);
-    });
-
-    it('should create and return an api', () => {
-      session.getObjectApi({ handle: -1, id: 'id_1234', type: 'Foo', customType: 'Bar' });
-      expect(definition.generate).to.be.calledWith('Foo');
-      expect(definition.create).to.be.calledWith(session, -1, 'id_1234', true, 'Bar');
-    });
-  });
-
-  describe('getPatchee', () => {
-    it('should get an existing patchee', () => {
-      const patchee = {};
-      session.apis.add(-1, {});
-      session.apis.addPatchee(-1, 'Foo', patchee);
-      expect(session.getPatchee(-1, [], 'Foo')).to.equal(patchee);
-      expect(session.getPatchee(-1, [], 'Foo')).to.equal(patchee);
-    });
-
-    it('should apply and return a patchee', () => {
-      const JSONPatch = sinon.stub(JSONPatchMock, 'apply');
-      session.apis.add(-1, {});
-      session.apis.addPatchee(-1, 'Foo', {});
-      session.getPatchee(-1, [{ op: 'add', path: '/', value: {} }], 'Foo');
-      expect(JSONPatch).to.have.been.calledWith({}, [{ op: 'add', path: '/', value: {} }]);
-      JSONPatch.reset();
-      session.apis.addPatchee(-1, 'Bar', []);
-      session.getPatchee(-1, [{ op: 'add', path: '/', value: [] }], 'Bar');
-      expect(JSONPatch).to.have.been.calledWith([], [{ op: 'add', path: '/', value: [] }]);
-
-      // primitive
-      JSONPatch.reset();
-      session.apis.addPatchee(-1, 'Baz', 'my folder');
-      session.getPatchee(-1, [{ op: 'add', path: '/', value: ['my documents'] }], 'Baz');
-      expect(JSONPatch.callCount).to.equal(0);
-    });
-
-    describe('primitive patch', () => {
-      let value;
-
-      beforeEach(() => {
-        session.apis.add(-1, {});
-      });
-
-      describe('add', () => {
-        const op = 'add';
-
-        it('should return a string', () => {
-          value = session.getPatchee(-1, [{ op, path: '/', value: 'A string' }], 'Foo');
-          expect(value).to.equal('A string');
-        });
-
-        it('should return a boolean', () => {
-          value = session.getPatchee(-1, [{ op, path: '/', value: true }], 'Foo');
-          expect(value).to.equal(true);
-        });
-
-        it('should return a number', () => {
-          value = session.getPatchee(-1, [{ op, path: '/', value: 123 }], 'Foo');
-          expect(value).to.equal(123);
-        });
-      });
-
-      describe('replace', () => {
-        const op = 'replace';
-
-        it('should return a string', () => {
-          value = session.getPatchee(-1, [{ op, path: '/', value: 'A string' }], 'Foo');
-          expect(value).to.equal('A string');
-        });
-
-        it('should return a boolean', () => {
-          value = session.getPatchee(-1, [{ op, path: '/', value: true }], 'Foo');
-          expect(value).to.equal(true);
-        });
-
-        it('should return a number', () => {
-          value = session.getPatchee(-1, [{ op, path: '/', value: 123 }], 'Foo');
-          expect(value).to.equal(123);
-        });
-      });
-
-      it('should cache primitive patches', () => {
-        value = session.getPatchee(-1, [{ op: 'add', path: '/', value: 'A string' }], 'Foo');
-        expect(value).to.equal('A string');
-        expect(session.getPatchee(-1, [], 'Foo')).to.equal(value);
-      });
-
-      it('should not throw if primitive patch already exists', () => {
-        session.getPatchee(-1, [{ op: 'add', path: '/', value: 'A string' }], 'Foo');
-        expect(session.getPatchee(-1, [{ op: 'replace', path: '/', value: 'Bar' }], 'Foo')).to.equal('Bar');
-      });
-    });
-  });
-
-  describe('intercept', () => {
-    it('should call interceptors onFulfilled', () => {
-      const interceptors = [{ onFulfilled: sinon.stub().returns({ bar: {} }) }];
-      return expect(session.intercept(Promise.resolve({ foo: {} }), interceptors))
-        .to.eventually.deep.equal({ bar: {} });
-    });
-
-    it('should reject and stop the interceptor chain', () => {
-      const spyFulFilled = sinon.spy();
-      const interceptors = [{ onFulfilled() { return Promise.reject('foo'); } }, { onFulfilled: spyFulFilled }];
-      return expect(session.intercept(Promise.resolve(), interceptors).then(() => {}, (err) => {
-        expect(spyFulFilled.callCount).to.equal(0);
-        return Promise.reject(err);
-      })).to.eventually.be.rejectedWith('foo');
-    });
-
-    it('should call interceptors onRejected', () => {
-      const onRejected = sinon.stub().returns('foo');
-      const interceptors = [{ onFulfilled() { return Promise.reject('foo'); } }, { onFulfilled() {}, onRejected }];
-      return expect(session.intercept(Promise.resolve(), interceptors, {})).to.eventually.equal('foo');
-    });
-  });
-
-  describe('processErrorInterceptor', () => {
-    it('should reject and emit if the response contains an error', () => {
-      const emit = sandbox.stub(session, 'emit');
-      return session.processErrorInterceptor({}, { error: 'FUBAR' }).then(null, (err) => {
-        expect(emit).to.have.been.calledWithExactly('qix-error', 'FUBAR');
-        expect(err).to.equal('FUBAR');
-      });
-    });
-
-    it('should not reject if the response does not contain any error', () => {
-      const response = {};
-      expect(session.processErrorInterceptor({}, response)).to.equal(response);
-    });
-  });
-
-  describe('processDeltaInterceptor', () => {
-    let response = { result: { foo: {} } };
-
-    it('should call getPatchee', () => {
-      response = { result: { qReturn: [{ foo: {} }] }, delta: true };
-      const stub = sinon.stub(session, 'getPatchee').returns(response.result.qReturn);
-      session.processDeltaInterceptor({ handle: 1, method: 'Foo', outKey: -1 }, response);
-      expect(stub).to.have.been.calledWith(1, response.result.qReturn, 'Foo-qReturn');
-    });
-
-    it('should reject when response is not an array of patches', () => {
-      response = { result: { qReturn: { foo: {} } }, delta: true };
-      return expect(session.processDeltaInterceptor({ handle: 1, method: 'Foo', outKey: -1 }, response)).to.eventually.be.rejectedWith('Unexpected rpc response, expected array of patches');
-    });
-
-    it('should return response if delta is falsy', () => {
-      response = { result: { qReturn: [{ foo: {} }] }, delta: false };
-      expect(session.processDeltaInterceptor({ handle: 1, method: 'Foo', outKey: -1 }, response)).to.equal(response);
-    });
-  });
-
-  describe('processResultInterceptor', () => {
-    const response = { result: { foo: {} } };
-
-    it('should return result', () => {
-      expect(session.processResultInterceptor({ outKey: -1 }, response))
-        .to.be.equal(response.result);
-    });
-  });
-
-  describe('processMultipleOutParamInterceptor', () => {
-    it('should append missing qGenericId for CreateSessionApp', () => {
-      const result = { qReturn: { qHandle: 1, qType: 'Doc' }, qSessionAppId: 'test' };
-      const out = session.processMultipleOutParamInterceptor({ method: 'CreateSessionApp' }, result);
-      expect(out.qReturn.qGenericId).to.be.equal(result.qSessionAppId);
-    });
-
-    it('should remove errenous qReturn from GetInteract', () => {
-      const result = { qReturn: false, qDef: 'test' };
-      const out = session.processMultipleOutParamInterceptor({ method: 'GetInteract' }, result);
-      expect(out.qReturn).to.be.equal(undefined);
-    });
-  });
-
-  describe('processOutInterceptor', () => {
-    it('should return result with out key', () => {
-      const result = { foo: { bar: {} } };
-      expect(session.processOutInterceptor({ outKey: 'foo' }, result)).to.be.equal(result.foo);
-    });
-
-    it('should return result with return key', () => {
-      const result = { qReturn: { foo: {} } };
-      expect(session.processOutInterceptor({ outKey: -1 }, result)).to.be.equal(result.qReturn);
-    });
-
-    it('should return result if neither out key or return key is specified', () => {
-      const result = { foo: {} };
-      expect(session.processOutInterceptor({ outKey: -1 }, result)).to.be.equal(result);
-    });
-  });
-
-  describe('processObjectApiInterceptor', () => {
-    it('should call getObjectApi', () => {
-      const response = { qHandle: 1, qType: 'Foo', qGenericId: 'Baz', qGenericType: 'Bar' };
-      const stub = sinon.stub(session, 'getObjectApi');
-      session.processObjectApiInterceptor({}, response);
-      expect(stub).to.have.been.calledWith({ handle: 1, type: 'Foo', id: 'Baz', customType: 'Bar', delta: true });
-    });
-
-    it("should return null if requested object doesn't exist", () => {
-      const response = { qHandle: null, qType: null };
-      return expect(session.processObjectApiInterceptor({}, response)).to.equal(null);
-    });
-
-    it('should return response argument if qHandle/qType are undefined', () => {
-      const response = {};
-      return expect(session.processObjectApiInterceptor({}, response)).to.equal(response);
-    });
   });
 
   describe('addToPromiseChain', () => {
@@ -600,6 +188,48 @@ describe('Session', () => {
       Session.addToPromiseChain(promise, 'foo', 'bar');
       const p1 = promise.then(s => `${s}1`);
       return expect(p1).to.eventually.equal('baz1');
+    });
+  });
+
+  describe('suspend/resume', () => {
+    it('should reject send() calls during suspended state', () => {
+      suspendResume.isSuspended = true;
+      expect(session.send()).to.eventually.be.rejectedWith('Session suspended');
+    });
+
+    it('should not trigger events during suspended state', () => {
+      suspendResume.isSuspended = true;
+      const spy = sinon.spy();
+      session.on('socket-error', spy);
+      session.on('suspended', spy);
+      session.on('closed', spy);
+      session.on('handle-changed', spy);
+      session.on('handle-closed', spy);
+      session.onError();
+      session.onClosed();
+      session.onMessage();
+      expect(spy.callCount).to.equal(0);
+    });
+
+    it('should close socket and emit suspended', () => {
+      const spy = sinon.spy();
+      const stub = sinon.stub(session.rpc, 'close').returns(Promise.resolve());
+      suspendResume.suspend = () => {};
+      session.on('suspended', spy);
+      return session.suspend().then(() => {
+        expect(stub.calledOnce).to.equal(true);
+        expect(spy.calledOnce).to.equal(true);
+      });
+    });
+
+    it('should open socket and emit resumed', () => {
+      const spy = sinon.spy();
+      suspendResume.suspend();
+      suspendResume.resume = () => Promise.resolve();
+      session.on('resumed', spy);
+      return session.resume().then(() => {
+        expect(spy.calledOnce).to.equal(true);
+      });
     });
   });
 });

--- a/test/unit/suspend-resume.spec.js
+++ b/test/unit/suspend-resume.spec.js
@@ -41,8 +41,8 @@ describe('Suspend/Resume', () => {
 
     it('should close doc', () => {
       const apisToClose = [
-        { emit: sinon.stub(), handle: 1, type: 'Doc', id: 1 },
-        { emit: sinon.stub(), handle: 2, type: 'GenericObject', id: 2 },
+        { emit: sinon.stub(), removeAllListeners: () => {}, handle: 1, type: 'Doc', id: 1 },
+        { emit: sinon.stub(), removeAllListeners: () => {}, handle: 2, type: 'GenericObject', id: 2 },
       ];
 
       apisToClose.concat([{ emit: sinon.stub(), handle: -1, type: 'Global' }]).forEach(api => apis.add(api.handle, api));
@@ -62,14 +62,14 @@ describe('Suspend/Resume', () => {
 
     it('should restore doc and objects', () => {
       const apisToChange = [
-        { emit: sinon.stub(), handle: 1, type: 'Doc', id: 1 },
-        { emit: sinon.stub(), handle: 2, type: 'GenericObject', id: 2 },
-        { emit: sinon.stub(), handle: 3, type: 'GenericVariable', id: 3 },
+        { emit: sinon.stub(), removeAllListeners: () => {}, handle: 1, type: 'Doc', id: 1 },
+        { emit: sinon.stub(), removeAllListeners: () => {}, handle: 2, type: 'GenericObject', id: 2 },
+        { emit: sinon.stub(), removeAllListeners: () => {}, handle: 3, type: 'GenericVariable', id: 3 },
       ];
       const apisToClose = [
-        { emit: sinon.stub(), handle: 4, type: 'Field', id: 4 },
-        { emit: sinon.stub(), handle: 5, type: 'GenericDummy', id: 5 },
-        { emit: sinon.stub(), handle: 6, type: 'GenericBookmark', id: 6 },
+        { emit: sinon.stub(), removeAllListeners: () => {}, handle: 4, type: 'Field', id: 4 },
+        { emit: sinon.stub(), removeAllListeners: () => {}, handle: 5, type: 'GenericDummy', id: 5 },
+        { emit: sinon.stub(), removeAllListeners: () => {}, handle: 6, type: 'GenericBookmark', id: 6 },
       ];
 
       apisToChange.concat(apisToClose).concat([{ emit: sinon.stub(), handle: -1, type: 'Global' }])

--- a/test/unit/suspend-resume.spec.js
+++ b/test/unit/suspend-resume.spec.js
@@ -23,7 +23,7 @@ describe('Suspend/Resume', () => {
   });
 
   describe('Suspend', () => {
-    it('should set state when suspended', () => suspendResume.suspend().then(() => expect(suspendResume.isSuspended).to.equal(true)));
+    it('should set state when manually suspended', () => suspendResume.suspend().then(() => expect(suspendResume.isSuspended).to.equal(true)));
   });
 
   describe('Resume', () => {

--- a/test/unit/suspend-resume.spec.js
+++ b/test/unit/suspend-resume.spec.js
@@ -1,0 +1,107 @@
+import Promise from 'bluebird';
+import SuspendResume from '../../src/suspend-resume';
+import RPC from '../../src/rpc';
+import SocketMock from '../mocks/socket-mock';
+import ApiCache from '../../src/api-cache';
+
+describe('Suspend/Resume', () => {
+  let suspendResume;
+  let rpc;
+  let apis;
+
+  beforeEach(() => {
+    SocketMock.on('created', socket => socket.open());
+    class Dummy extends RPC { reopen() { return super.reopen(5); } }
+    rpc = new Dummy({ Promise, url: 'http://localhost:4848', createSocket: url => new SocketMock(url, false) });
+    apis = new ApiCache({ Promise, schema: {} });
+    suspendResume = new SuspendResume({ Promise, rpc, apis });
+  });
+
+  afterEach(() => {
+    SocketMock.removeAllListeners('created');
+  });
+
+  describe('Suspend', () => {
+    it('should set state when suspended', () => {
+      suspendResume.suspend();
+      expect(suspendResume.isSuspended).to.equal(true);
+    });
+  });
+
+  describe('Resume', () => {
+    it('should reject created sessions when onlyIfAttached is true', () => {
+      suspendResume.suspend();
+      const p = rpc.open().then(() => suspendResume.resume(true));
+      expect(p).to.eventually.be.rejectedWith('Not attached');
+    });
+
+    it('should restore global', () => {
+      apis.add(-1, { emit: sinon.stub(), handle: -1, type: 'Global' });
+      return rpc.open()
+        .then(() => suspendResume.resume())
+        .then(() => expect(apis.getApi(-1).emit.notCalled).to.equal(true));
+    });
+
+    it('should close doc', () => {
+      const apisToClose = [
+        { emit: sinon.stub(), handle: 1, type: 'Doc', id: 1 },
+        { emit: sinon.stub(), handle: 2, type: 'GenericObject', id: 2 },
+      ];
+
+      apisToClose.concat([{ emit: sinon.stub(), handle: -1, type: 'Global' }]).forEach(api => apis.add(api.handle, api));
+
+      SocketMock.on('created', (socket) => {
+        socket.intercept('GetActiveDoc').return({ error: { message: 'Oh, no!' } });
+        socket.intercept('OpenDoc').return({ error: { message: 'Oh, no!' } });
+      });
+
+      suspendResume.suspend();
+
+      return rpc.open()
+        .then(() => suspendResume.resume(false))
+        .then(() => {
+          expect(apis.getApis().length).to.equal(1);
+          apisToClose.forEach(api => expect(api.emit).to.have.been.calledWith('closed'));
+        });
+    });
+
+    it('should restore doc and objects', () => {
+      const apisToChange = [
+        { emit: sinon.stub(), handle: 1, type: 'Doc', id: 1 },
+        { emit: sinon.stub(), handle: 2, type: 'GenericObject', id: 2 },
+        { emit: sinon.stub(), handle: 3, type: 'GenericVariable', id: 3 },
+      ];
+      const apisToClose = [
+        { emit: sinon.stub(), handle: 4, type: 'Field', id: 4 },
+        { emit: sinon.stub(), handle: 5, type: 'GenericDummy', id: 5 },
+        { emit: sinon.stub(), handle: 6, type: 'GenericBookmark', id: 6 },
+      ];
+
+      apisToChange.concat(apisToClose).concat([{ emit: sinon.stub(), handle: -1, type: 'Global' }])
+        .forEach(api => apis.add(api.handle, api));
+
+      SocketMock.on('created', (socket) => {
+        socket.intercept('GetActiveDoc').return({ result: { qReturn: { qHandle: 101 } } });
+        socket.intercept('GetObject').return({ result: { qReturn: { qHandle: 102 } } });
+        socket.intercept('GetVariableById').return({ result: { qReturn: { qHandle: 103 } } });
+        socket.intercept('GetDummy').return({ error: {} });
+        socket.intercept('GetBookmark').return({ result: { qReturn: { qHandle: null } } });
+      });
+
+      suspendResume.suspend();
+
+      return rpc.open()
+        .then(() => suspendResume.resume(true))
+        .catch(() => {
+          apisToChange.forEach(api => expect(api.emit.notCalled).to.equal(true));
+          apisToClose.forEach(api => expect(api.emit.notCalled).to.equal(true));
+        })
+        .then(() => suspendResume.resume(false))
+        .then(() => {
+          expect(apis.getApis().length).to.equal(4);
+          apisToChange.forEach(api => expect(api.emit).to.have.been.calledWith('changed'));
+          apisToClose.forEach(api => expect(api.emit).to.have.been.calledWith('closed'));
+        });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #93 

session.js is now split up to three separate files:

* session.js handling the overall API to the socket
* suspend-resume.js handling the suspend/resume internal logic
* intercept.js handling the processing of socket messages
* Moved traffic event triggers from Session to RPC which enables us to capture traffic during suspended state too

This introduces less coupling and easier to maintain in the long run.

Breaking changes:

* The event `qix-error` is no longer triggered on session (never documented)
* The second parameter to `createSocket`, `sessionConfig` is no longer passed in