### PR TITLE
Add enigma.min.js output during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-filesize": "^1.3.2",
+    "rollup-plugin-multi-dest": "^1.0.2",
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-globals": "^1.1.0",
     "rollup-plugin-node-resolve": "^3.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,10 +4,11 @@ import nodeGlobals from 'rollup-plugin-node-globals';
 import nodeBuiltins from 'rollup-plugin-node-builtins';
 import commonjs from 'rollup-plugin-commonjs';
 import babel from 'rollup-plugin-babel';
+import multidest from 'rollup-plugin-multi-dest';
 import uglify from 'rollup-plugin-uglify';
 import filesize from 'rollup-plugin-filesize';
 
-export default {
+export default [{
   entry: 'src/qix.js',
   dest: 'dist/enigma.js',
   moduleName: 'enigma',
@@ -26,7 +27,13 @@ export default {
       presets: ['es2015-rollup'],
       plugins: ['external-helpers', 'transform-object-assign'],
     }),
-    uglify(),
+    multidest([{
+      dest: 'dist/enigma.min.js',
+      format: 'umd',
+      plugins: [
+        uglify(),
+      ],
+    }]),
     filesize(),
   ],
-};
+}];


### PR DESCRIPTION
Fixes #96 

```bash
> rollup -c

┌───────────────────────────────────────────────────┐
│                                                   │
│   Destination: dist/enigma.js                     │
│   Bundle size: 82.54 KB, Gzipped size: 19.59 KB   │
│                                                   │
└───────────────────────────────────────────────────┘
┌────────────────────────────────────────────────┐
│                                                │
│   Destination: dist/enigma.min.js              │
│   Bundle size: 27.3 KB, Gzipped size: 8.2 KB   │
│                                                │
└────────────────────────────────────────────────┘
```