### PR TITLE
Add license header to dist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-filesize": "^1.3.2",
+    "rollup-plugin-license": "^0.4.0",
     "rollup-plugin-multi-dest": "^1.0.2",
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-globals": "^1.1.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,9 @@ import babel from 'rollup-plugin-babel';
 import multidest from 'rollup-plugin-multi-dest';
 import uglify from 'rollup-plugin-uglify';
 import filesize from 'rollup-plugin-filesize';
+import license from 'rollup-plugin-license';
+
+const pkg = require('./package.json');
 
 export default [{
   entry: 'src/qix.js',
@@ -34,6 +37,13 @@ export default [{
         uglify(),
       ],
     }]),
+    license({
+      banner: `
+        ${pkg.name} v${pkg.version}
+        Copyright (c) ${new Date().getFullYear()} QlikTech International AB
+        This library is licensed under MIT - See the LICENSE file for full details
+      `,
+    }),
     filesize(),
   ],
 }];


### PR DESCRIPTION
Creates a header in each `dist/` file containing:

```
/**
 * enigma.js v1.2.1
 * Copyright (c) 2017 QlikTech International AB
 * This library is licensed under MIT - See the LICENSE file for full details
 */
```