### PR TITLE
Expose args.config in mixin.init()

### DIFF
--- a/docs/qix/mixins.md
+++ b/docs/qix/mixins.md
@@ -15,14 +15,13 @@ const appMixin = {
 	* An array of strings specifying which api types this mixin applies to. It works with a single
 	* string as well.
 	*/
-	types: ["Doc"], // An app has the typename "Doc" which is a QlikView legacy name.
+	types: ["Doc"], // An app has the typename "Doc".
 
 	/**
 	 * Initialization function. Called when an instance of the specified API(s) is created
 	 * before applying the mixins.
 	 * @param {Object} args - Object containing init parameters.
-	 * @param {Function} args.Promise - The promise library that was used when setting up
-	 * the qix service
+	 * @param {Configuration} args.config - The enigma.js configuration.
 	 * @param {Object} args.api - The object instance that was just created.
 	 */
 	init: ( args ) => {

--- a/src/api-cache.js
+++ b/src/api-cache.js
@@ -10,7 +10,7 @@ class ApiCache extends KeyValueCache {
   * Create a new ApiCache instance.
   * @param {Object} options The configuration options for this class.
   * @param {Promise} options.Promise The promise constructor to use.
-  * @param {Schema} options.schema The schema instance to use.
+  * @param {Schema} options.definition The definition instance to use.
   */
   constructor(options) {
     super();
@@ -72,7 +72,7 @@ class ApiCache extends KeyValueCache {
     if (api) {
       return api;
     }
-    api = this.schema
+    api = this.definition
       .generate(type)
       .create(this.session, handle, id, delta, customType);
     this.add(handle, api);

--- a/src/qix.js
+++ b/src/qix.js
@@ -15,7 +15,7 @@ class Qix {
   * @typedef {Object} Configuration
   * @property {Function} createSocket A function to use when instantiating the WebSocket.
   *                                   Mandatory for NodeJS.
-  * @property {Object} schema The JSON object describing the api.
+  * @property {Object} schema The JSON object describing the API.
   * @property {Promise} [Promise] The promise constructor to use.
   * @property {Boolean} [suspendOnClose=false] Set to true if the session should be suspended
   *                             and not closed if the WebSocket is closed unexpectedly.
@@ -42,9 +42,9 @@ class Qix {
       Promise,
       responseInterceptors,
       JSONPatch,
-      schema,
+      definition,
     } = config;
-    const apis = new ApiCache({ Promise, schema });
+    const apis = new ApiCache({ Promise, definition });
     const rpc = new RPC({ url, createSocket, delta, Promise });
     const suspendResume = new SuspendResume({ rpc, Promise, apis });
     const intercept = new Intercept({
@@ -118,7 +118,7 @@ class Qix {
   static connect(config) {
     Qix.configureDefaults(config);
     config.mixins.forEach((mixin) => {
-      config.schema.registerMixin(mixin);
+      config.definition.registerMixin(mixin);
     });
     const session = Qix.getSession(config);
     return Qix.get(session, config);
@@ -146,13 +146,10 @@ class Qix {
       config.suspendOnClose = false;
     }
 
-    if (!(config.schema instanceof Schema)) {
-      config.schema = new Schema(config.Promise, config.schema);
-    }
-
     config.Promise = config.Promise || Promise;
     config.mixins = config.mixins || [];
     config.JSONPatch = config.JSONPatch || Patch;
+    config.definition = config.definition || new Schema(config);
   }
 }
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -50,13 +50,13 @@ class Schema {
 
   /**
   * Create a new schema instance.
-  * @param {Function} Promise The constructor function for a promise.
-  * @param {Object} json The JSON object that describes the API.
+  * @param {Configuration} config The configuration for QIX.
   */
-  constructor(Promise, json) {
-    this.Promise = Promise;
+  constructor(config) {
+    this.config = config;
+    this.Promise = config.Promise;
+    this.schema = config.schema;
     this.mixins = new KeyValueCache();
-    this.def = json;
     this.types = new KeyValueCache();
   }
 
@@ -103,10 +103,10 @@ class Schema {
     if (entry) {
       return entry;
     }
-    if (!this.def.structs[type]) {
+    if (!this.schema.structs[type]) {
       throw new Error(`${type} not found`);
     }
-    const factory = this.generateApi(type, this.def.structs[type]);
+    const factory = this.generateApi(type, this.schema.structs[type]);
     this.types.add(type, factory);
     return factory;
   }
@@ -165,7 +165,7 @@ class Schema {
       }
       mixinList.forEach((mixin) => {
         if (typeof mixin.init === 'function') {
-          mixin.init({ Promise: this.Promise, api: instance });
+          mixin.init({ config: this.config, api: instance });
         }
       });
 

--- a/test/component/doc.spec.js
+++ b/test/component/doc.spec.js
@@ -1,5 +1,5 @@
 import Promise from 'bluebird';
-import Schema from '../../schemas/qix/3.2/schema.json';
+import schema from '../../schemas/qix/3.2/schema.json';
 import Qix from '../../src/qix';
 import SocketMock from '../mocks/socket-mock';
 
@@ -19,7 +19,7 @@ describe('QIX Doc', () => {
     sandbox = sinon.sandbox.create();
 
     config.Promise = Promise;
-    config.schema = Schema;
+    config.schema = schema;
     config.session = {
       route: 'app/engineData',
       host: 'mocked',
@@ -69,7 +69,7 @@ describe('QIX Doc', () => {
       });
     });
     it('should return a barchart GenericObject with the expected members', () => {
-      const keys = Object.keys(Schema.structs.GenericObject).map(key =>
+      const keys = Object.keys(schema.structs.GenericObject).map(key =>
         key.substring(0, 1).toLowerCase() + key.substring(1)
       );
       expect(Object.keys(Object.getPrototypeOf(barchartObject))).to.include.members(keys);

--- a/test/component/global.spec.js
+++ b/test/component/global.spec.js
@@ -1,5 +1,5 @@
 import Promise from 'bluebird';
-import Schema from '../../schemas/qix/3.2/schema.json';
+import schema from '../../schemas/qix/3.2/schema.json';
 import Qix from '../../src/qix';
 import SocketMock from '../mocks/socket-mock';
 
@@ -18,7 +18,7 @@ describe('QIX Global', () => {
     sandbox = sinon.sandbox.create();
 
     config.Promise = Promise;
-    config.schema = Schema;
+    config.schema = schema;
     config.session = {
       route: 'app/engineData',
       host: 'mocked',

--- a/test/integration/global.spec.js
+++ b/test/integration/global.spec.js
@@ -1,7 +1,7 @@
 import Promise from 'bluebird';
 import WebSocket from 'ws';
 import Qix from '../../src/qix';
-import Schema from '../../schemas/qix/3.2/schema.json';
+import schema from '../../schemas/qix/3.2/schema.json';
 import utils from './utils';
 
 describe('QIX Global', () => {
@@ -13,7 +13,7 @@ describe('QIX Global', () => {
     utils.getDefaultConfig().then((cfg) => {
       config = cfg;
       config.Promise = Promise;
-      config.schema = Schema;
+      config.schema = schema;
       config.mixins = [{
         types: 'Global',
         extend: {

--- a/test/integration/sugar-mixins.spec.js
+++ b/test/integration/sugar-mixins.spec.js
@@ -1,7 +1,7 @@
 import Promise from 'bluebird';
 import WebSocket from 'ws';
 import Qix from '../../src/qix';
-import Schema from '../../schemas/qix/3.2/schema.json';
+import schema from '../../schemas/qix/3.2/schema.json';
 import utils from './utils';
 
 describe('Sugar mixins', () => {
@@ -14,7 +14,7 @@ describe('Sugar mixins', () => {
     config.createSocket = url =>
       new WebSocket(url, config.socket);
     config.Promise = Promise;
-    config.schema = Schema;
+    config.schema = schema;
     config.mixins = [{
       types: 'Global',
       extend: {

--- a/test/integration/traffic.spec.js
+++ b/test/integration/traffic.spec.js
@@ -3,7 +3,7 @@ import chaiSubset from 'chai-subset';
 import Promise from 'bluebird';
 import WebSocket from 'ws';
 import Qix from '../../src/qix';
-import Schema from '../../schemas/qix/3.2/schema.json';
+import schema from '../../schemas/qix/3.2/schema.json';
 import utils from './utils';
 
 chai.use(chaiSubset);
@@ -20,7 +20,7 @@ describe('qix-logging', () => {
       sandbox = sinon.sandbox.create();
       // isServer = defaultConfig.isServer;
       config.Promise = Promise;
-      config.schema = Schema;
+      config.schema = schema;
       config.listeners = {
         'traffic:sent': sinon.spy(),
         'traffic:received': sinon.spy(),

--- a/test/unit/api-cache.spec.js
+++ b/test/unit/api-cache.spec.js
@@ -2,14 +2,14 @@ import ApiCache from '../../src/api-cache';
 
 describe('ApiCache', () => {
   let apiCache;
-  let schema;
+  let definition;
 
   beforeEach(() => {
-    schema = {
+    definition = {
       generate: sinon.stub().returnsThis(),
       create: sinon.stub().returnsArg(1),
     };
-    apiCache = new ApiCache({ schema });
+    apiCache = new ApiCache({ definition });
     apiCache.session = {};
   });
 
@@ -128,8 +128,8 @@ describe('ApiCache', () => {
 
     it('should create and return an api', () => {
       apiCache.getObjectApi({ handle: -1, id: 'id_1234', type: 'Foo', customType: 'Bar' });
-      expect(schema.generate).to.be.calledWith('Foo');
-      expect(schema.create).to.be.calledWith(apiCache.session, -1, 'id_1234', true, 'Bar');
+      expect(definition.generate).to.be.calledWith('Foo');
+      expect(definition.create).to.be.calledWith(apiCache.session, -1, 'id_1234', true, 'Bar');
     });
   });
 });

--- a/test/unit/qix.spec.js
+++ b/test/unit/qix.spec.js
@@ -116,9 +116,9 @@ describe('Qix', () => {
     });
 
     it('should keep constructed QixDefinition', () => {
-      config.schema = new Schema(Promise, {});
+      config.definition = new Schema(Promise, {});
       Qix.connect(config);
-      expect(Qix.getSession).to.be.calledWithMatch({ schema: config.schema });
+      expect(Qix.getSession).to.be.calledWithMatch({ definition: config.definition });
     });
 
     it('should default JSONPatch', () => {


### PR DESCRIPTION
Fixes #18, #33 

Also rename 'schema' instances internally to 'definition' to keep 'schema' JSON intact.