### PR TITLE
Renamed handle-changed and handle-closed events

### DIFF
--- a/src/session.js
+++ b/src/session.js
@@ -28,8 +28,8 @@ class Session {
     session.rpc.on('message', session.onMessage.bind(session));
     session.rpc.on('notification', session.onNotification.bind(session));
     session.rpc.on('traffic', session.onTraffic.bind(session));
-    session.on('handle-changed', handle => session.apis.onHandleChanged(handle));
-    session.on('handle-closed', handle => session.apis.onHandleClosed(handle));
+    session.on('handle:changed', handle => session.apis.onHandleChanged(handle));
+    session.on('handle:closed', handle => session.apis.onHandleClosed(handle));
     session.on('closed', () => session.apis.onSessionClosed());
   }
 
@@ -67,8 +67,8 @@ class Session {
 
   /**
   * Event handler for the RPC message event.
-  * @emits handle-changed
-  * @emits handle-closed
+  * @emits handle:changed
+  * @emits handle:closed
   * @param {Object} response JSONRPC response.
   */
   onMessage(response) {
@@ -76,10 +76,10 @@ class Session {
       return;
     }
     if (response.change) {
-      response.change.forEach(handle => this.emit('handle-changed', handle));
+      response.change.forEach(handle => this.emit('handle:changed', handle));
     }
     if (response.close) {
-      response.close.forEach(handle => this.emit('handle-closed', handle));
+      response.close.forEach(handle => this.emit('handle:closed', handle));
     }
   }
 

--- a/test/unit/session.spec.js
+++ b/test/unit/session.spec.js
@@ -193,13 +193,13 @@ describe('Session', () => {
     session.removeAllListeners();
 
     const changeSpy = sinon.spy();
-    session.on('handle-changed', changeSpy);
+    session.on('handle:changed', changeSpy);
 
     rpc.emit('message', { change: [1, 2, 3] });
     expect(changeSpy.calledThrice).to.equal(true);
 
     const closeSpy = sinon.spy();
-    session.on('handle-closed', closeSpy);
+    session.on('handle:closed', closeSpy);
 
     rpc.emit('message', { close: [1, 2, 3] });
     expect(closeSpy.calledThrice).to.equal(true);
@@ -260,8 +260,8 @@ describe('Session', () => {
       session.on('socket-error', spy);
       session.on('suspended', spy);
       session.on('closed', spy);
-      session.on('handle-changed', spy);
-      session.on('handle-closed', spy);
+      session.on('handle:changed', spy);
+      session.on('handle:closed', spy);
       session.onError();
       session.onClosed();
       session.onMessage();


### PR DESCRIPTION
New names are `handle:changed` and `handle:closed`.