### PR TITLE
test(session): add missing `getObjectApi` mock

### DIFF
--- a/test/unit/session.spec.js
+++ b/test/unit/session.spec.js
@@ -217,6 +217,7 @@ describe('Session', () => {
   it('should close', () => {
     const rpc = new RPCMock({ Promise, url: 'http://localhost:4848', createSocket: url => new SocketMock(url) });
     createSession(false, rpc);
+    session.getObjectApi = () => {};
     session.open();
     const close = sinon.spy(rpc, 'close');
     const closePromise = session.close();


### PR DESCRIPTION
Got an error running the tests. This fixes it.