### PR TITLE
don't rely on successful websocket closure for session suspension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.1
+
+- bug fix -essentially port back a fix from v2.0 such that engima marks the session as suspended at the place/point
+           where the websocket is closed.
+
+
 ## 1.3.0
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enigma.js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "JavaScript library for consuming Qlik backend services",
   "author": "QlikTech International AB",
   "license": "MIT",

--- a/src/services/qix/session.js
+++ b/src/services/qix/session.js
@@ -182,6 +182,10 @@ class Session {
   * @returns {Object} Returns a promise instance.
   */
   suspend() {
+    // don't rely on properly closing of websocket to set suspended flag .. need
+    // to handle cases where websocket closes abnormally as well.
+    this.suspended = true;
+
     return this.rpc.close(RPC_CLOSE_MANUAL_SUSPEND)
       .then(() => this.emit('suspended', { initiator: 'manual' }));
   }


### PR DESCRIPTION
On iOS suspension was failing roughly 10% of the time since the websocket closure
was sometimes abnormal. This resulted in websocket onClose status code of 
1006 which caused enigma to believe that the closure was not due to manual
suspension. My fix essentially ports back the behavior from enigma v2.0 where the 
susepended flag is explicitly set when/where the socket is closed.