### PR TITLE
Reject with an error instance

### DIFF
--- a/src/intercept.js
+++ b/src/intercept.js
@@ -92,7 +92,11 @@ class Intercept {
   */
   processErrorInterceptor(meta, response) {
     if (typeof response.error !== 'undefined') {
-      return this.Promise.reject(response.error);
+      const data = response.error;
+      const error = new Error(data.message);
+      error.code = data.code;
+      error.parameter = data.parameter;
+      return this.Promise.reject(error);
     }
     return response;
   }

--- a/test/unit/intercept.spec.js
+++ b/test/unit/intercept.spec.js
@@ -125,8 +125,14 @@ describe('Intercept', () => {
   });
 
   describe('processErrorInterceptor', () => {
-    it('should reject and emit if the response contains an error', () => intercept.processErrorInterceptor({}, { error: 'FUBAR' }).then(null, (err) => {
-      expect(err).to.equal('FUBAR');
+    it('should reject and emit if the response contains an error', () => intercept.processErrorInterceptor({}, { error: { code: 2, parameter: 'param', message: 'msg' } }).then(null, (err) => {
+      expect(err instanceof Error).to.equal(true);
+      expect(err.code).to.equal(2);
+      expect(err.parameter).to.equal('param');
+      expect(err.message).to.equal('msg');
+      expect(err.stack).to.be.a('string');
+      // check if the test file is included in the stack trace:
+      expect(err.stack.indexOf('intercept.spec.js')).to.not.equal(-1);
     }));
 
     it('should not reject if the response does not contain any error', () => {


### PR DESCRIPTION
Fixes #163 

This enables end-users to debug their implementation easier by checking the stack trace:

```js
process.on('unhandledRejection', (reason, p) => {
  console.log('Unhandled Rejection at:', p, 'reason:', reason);
  console.log('Stack:', reason.stack);
});
```

It also quiets a warning log (when `NODE_ENV=production`) from the bluebird Promise library.