### PR TITLE
Bump circleci build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/enigma.js
     docker:
-      - image: circleci/node:8.1.2
+      - image: circleci/node:8.2.1
     environment:
       - NPM_CONFIG_LOGLEVEL=warn
     steps:
@@ -12,7 +12,7 @@ jobs:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install dependencies
-          command: npm install
+          command: npm install --no-save
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:


### PR DESCRIPTION
This fixes the dependency cache diffing before/after running npm install on circle ci
