### PR TITLE
Inject session to interceptors

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -13,8 +13,8 @@ Table of contents
   - [`mixin.extend.myNonExistingMethod()`](#mixinextendmynonexistingmethodparam1-param2-)
   - [`mixin.override.someExistingMethod()`](#mixinoverridesomeexistingmethodbase-param1-param2-)
 - [Interceptors](#interceptors)
-  - [`interceptor.onRejected()`](#interceptoronrejectedrequest-error)
-  - [`interceptor.onFulfilled()`](#interceptoronfulfilledrequest-result)
+  - [`interceptor.onRejected()`](#interceptoronrejectedsession-request-error)
+  - [`interceptor.onFulfilled()`](#interceptoronfulfilledsession-request-result)
 - [Session API](#session-api)
   - [`session.open()`](#sessionopen)
   - [`session.close()`](#sessionclose)
@@ -165,20 +165,24 @@ application.
 See the [Interceptor examples](/examples/README.md#interceptors) on how to use it, below
 is an outline of what the interceptor API consists of.
 
-### `interceptor.onRejected(request, error)`
+### `interceptor.onRejected(session, request, error)`
 
 This method is invoked when a previous interceptor has rejected the promise, use this
 to handle for example errors before they are sent into mixins.
+
+`session` refers to the session executing the interceptor.
 
 `request` is the JSON-RPC request resulting in this error. You may use `.retry()`
 to retry sending it to QIX Engine.
 
 `error` is whatever the previous interceptor rejected with.
 
-### `interceptor.onFulfilled(request, result)`
+### `interceptor.onFulfilled(session, request, result)`
 
 This method is invoked when a promise has been successfully resolved, use this
 to modify the result or reject the promise chain before it is sent to mixins.
+
+`session` refers to the session executing the interceptor.
 
 `request` is the JSON-RPC request resulting in this response.
 

--- a/examples/interceptors/retry-aborted/retry-aborted.js
+++ b/examples/interceptors/retry-aborted/retry-aborted.js
@@ -22,7 +22,7 @@ const session = enigma.create({
   createSocket: url => new WebSocket(url),
   responseInterceptors: [{
     // We only want to handle failed responses from QIX Engine:
-    onRejected: function retryAbortedError(request, error) {
+    onRejected: function retryAbortedError(sessionReference, request, error) {
       console.log('Request: Rejected', error);
       // We only want to handle aborted QIX errors:
       if (error.code === schema.enums.LocalizedErrorCode.LOCERR_GENERIC_ABORTED) {

--- a/src/session.js
+++ b/src/session.js
@@ -184,7 +184,7 @@ class Session {
     request.id = data.id;
     request.retry = () => this.send(request);
 
-    const promise = this.intercept.execute(response, request).then((res) => {
+    const promise = this.intercept.execute(this, response, request).then((res) => {
       if (typeof res.qHandle !== 'undefined' && typeof res.qType !== 'undefined') {
         return this.handleObjectReferenceResponse(res);
       }

--- a/test/unit/session.spec.js
+++ b/test/unit/session.spec.js
@@ -11,7 +11,7 @@ describe('Session', () => {
   let suspendResume;
   let apis;
 
-  const intercept = { execute: promise => promise };
+  const intercept = { execute: (sess, promise) => promise };
   const createSession = (throwError, rpc, suspendOnClose = false) => {
     const defaultRpc = new RPCMock({
       Promise,


### PR DESCRIPTION
Fixes #177 

All interceptors now get the `session` reference as a first parameter (internal breaking change).