### PR TITLE
Refactored handleObjectReferenceResponse into a response interceptor

### DIFF
--- a/src/intercept.js
+++ b/src/intercept.js
@@ -1,3 +1,4 @@
+import api from './interceptors/response/api';
 import delta from './interceptors/response/delta';
 import error from './interceptors/response/error';
 import outParam from './interceptors/response/out-param';
@@ -19,6 +20,7 @@ class Intercept {
       { onFulfilled: delta },
       { onFulfilled: result },
       { onFulfilled: outParam },
+      { onFulfilled: api },
       ...this.interceptors || [],
     ];
   }

--- a/src/interceptors/response/api.js
+++ b/src/interceptors/response/api.js
@@ -1,0 +1,21 @@
+/**
+* Response interceptor for generating APIs. Handles the quirks of engine not
+* returning an error when an object is missing.
+* @param {Object} session - The session the intercept is being executed on.
+* @param {Object} request - The JSON-RPC request.
+* @param {Object} response - The response.
+* @returns {Object} - Returns the generated API
+*/
+export default function apiInterceptor(session, request, response) {
+  if (response.qHandle && response.qType) {
+    return session.getObjectApi({
+      handle: response.qHandle,
+      type: response.qType,
+      id: response.qGenericId,
+      genericType: response.qGenericType,
+    });
+  } else if (response.qHandle === null && response.qType === null) {
+    throw new Error('Object not found');
+  }
+  return response;
+}

--- a/src/session.js
+++ b/src/session.js
@@ -141,24 +141,6 @@ class Session {
   }
 
   /**
-  * Response handler for generating APIs. Handles the quirks of engine not returning an error
-  * when an object is missing.
-  * @param {Object} response The response message.
-  * @returns {Promise} A promise that resolves with the created object.
-  */
-  handleObjectReferenceResponse(response) {
-    if (response.qHandle && response.qType) {
-      return this.getObjectApi({
-        handle: response.qHandle,
-        type: response.qType,
-        id: response.qGenericId,
-        genericType: response.qGenericType,
-      });
-    }
-    return this.Promise.reject(new Error('Object not found'));
-  }
-
-  /**
   * Establishes the RPC socket connection and returns the Global instance.
   * @returns {Promise} Eventually resolved if the connection was successful.
   */
@@ -199,12 +181,7 @@ class Session {
     request.id = data.id;
     request.retry = () => this.send(request);
 
-    const promise = this.intercept.execute(this, response, request).then((res) => {
-      if (typeof res.qHandle !== 'undefined' && typeof res.qType !== 'undefined') {
-        return this.handleObjectReferenceResponse(res);
-      }
-      return res;
-    });
+    const promise = this.intercept.execute(this, response, request);
     Session.addToPromiseChain(promise, 'requestId', request.id);
     return promise;
   }

--- a/test/unit/interceptors/response/api.spec.js
+++ b/test/unit/interceptors/response/api.spec.js
@@ -1,0 +1,23 @@
+import apiInterceptor from '../../../../src/interceptors/response/api';
+
+describe('Response interceptor: API', () => {
+  it('should generate api if handle/type exists', () => {
+    const session = { getObjectApi: sinon.stub().returns('dummy') };
+    const response = { qHandle: 1, qType: 'Doc', qGenericId: '123' };
+    const out = apiInterceptor(session, {}, response);
+    expect(session.getObjectApi.called).to.equal(true);
+    expect(out).to.equal('dummy');
+  });
+
+  it('should throw error when handle/type is null', () => {
+    const session = { getObjectApi: sinon.stub().returns('dummy') };
+    const response = { qHandle: null, qType: null };
+    expect(() => apiInterceptor(session, {}, response)).to.throw();
+  });
+
+  it('should leave response untouched if handle/type is missing', () => {
+    const response = { foo: { bar: {} } };
+    const out = apiInterceptor({}, {}, response);
+    expect(out).to.equal(response);
+  });
+});


### PR DESCRIPTION
No issue available.

Refectored `Session.handleObjectReferenceRespone()` into a response interceptor based on the idea @stoffeastrom raised [here](https://github.com/qlik-oss/enigma.js/pull/237).