### PR TITLE
Bump build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/enigma.js
     docker:
-      - image: circleci/node:8.4.0
+      - image: circleci/node:8.6.0
     environment:
       - NPM_CONFIG_LOGLEVEL=warn
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install dependencies
-          command: npm install
+          command: npm install --no-save
       - run:
           name: greenkeeper - Upload
           command: greenkeeper-lockfile-upload


### PR DESCRIPTION
Should fix the cache restoration issue in CCI.

Before:
![screen shot 2017-10-05 at 16 19 07](https://user-images.githubusercontent.com/83221/31232062-fb90b01a-a9e8-11e7-8d95-53aaa89c0fad.png)

After (cache key same before and after `npm install`):
![screen shot 2017-10-05 at 16 18 56](https://user-images.githubusercontent.com/83221/31232048-f580e370-a9e8-11e7-907d-ebb14b733900.png)
