### PR TITLE
Re-introduce delay in traffic log integration test

### DIFF
--- a/test/integration/traffic.spec.js
+++ b/test/integration/traffic.spec.js
@@ -43,7 +43,9 @@ describe('qix-logging', () => {
         qReturn: true,
       },
     };
-    return qixGlobal.allowCreateApp().then(() => {
+
+    const delay = new Promise((resolve) => { setTimeout(() => resolve(), 100); });
+    return delay.then(() => qixGlobal.allowCreateApp()).then(() => {
       // we have traffic:received for OnConnected notification before (so second received
       // msg should be ours):
       expect(sentSpy.firstCall.args[0]).to.containSubset(request);


### PR DESCRIPTION
When replacing our `bluebird` usage with native promises, a short delay in the traffic-log integration test was removed. This caused the tests to fail intermittently. In this commit the delay is re-introduced.