### PR TITLE
fix: do not apply named parameter on array

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -21,7 +21,7 @@ function toCamelCase(symbol) {
  * @param {*} params The parameters.
  */
 function namedParamFacade(base, defaults, ...params) {
-  if (params.length === 1 && typeof params[0] === 'object') {
+  if (params.length === 1 && typeof params[0] === 'object' && !Array.isArray(params[0])) {
     const valid = Object.keys(params[0]).every(key => hasOwnProperty.call(defaults, key));
     if (valid) {
       params = Object.keys(defaults).map(key => params[0][key] || defaults[key]);

--- a/test/unit/schema.spec.js
+++ b/test/unit/schema.spec.js
@@ -228,6 +228,10 @@ describe('Schema', () => {
                 { Name: 'param3', DefaultValue: 'xyz' }],
               Out: [],
             },
+            Baz: {
+              In: [{ Name: 'myBreakpoints', DefaultValue: [{ a: '', b: 0, c: false }] }],
+              Out: [],
+            },
           },
         },
       };
@@ -252,6 +256,15 @@ describe('Schema', () => {
       const api = factory({ send }, 1, 'dummy', false, 'dummy');
       api.bar({ param1: 'abc', param2: 'def' });
       expect(args).to.deep.equal(['abc', 'def', 'xyz']);
+    });
+
+    it('should NOT fill in default values when parameter is an array', () => {
+      let args;
+      const send = (request) => { args = request.params; };
+      const factory = definition.generate('Foo');
+      const api = factory({ send }, 1, 'dummy', false, 'dummy');
+      api.baz([]);
+      expect(args).to.deep.equal([[]]);
     });
 
     it('parameters should be passed as an array to mixins', () => {


### PR DESCRIPTION
This ensures we are not applying named parameters logic when an array is passed
