### PR TITLE
Fix typo and change QIX method for version

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,15 +107,14 @@ Create a HTML file `index.html` and insert the following example content:
       const session = enigma.create({
         schema,
         // Change the url to point to your QIX instance
-        url: 'ws://localhost:4848/app/engineData',
+        url: 'ws://localhost:9076/app/engineData',
         createSocket: url => new WebSocket(url)
       })
 
       session.open()
-        .then(global => global.productVersion())
-        .then(version => document.body.insnerHTML = version)
+        .then(global => global.engineVersion())
+        .then(result => document.body.innerHTML = result.qComponentVersion)
         .then(() => session.close())
-  
-    })
+    });
 </script>
 ```


### PR DESCRIPTION
The previous example had a typo (`innerHTML`) as well as using a deprecated QIX method to fetch the version.