### PR TITLE
Remove greenkeeper CI logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,20 +8,11 @@ jobs:
       - NPM_CONFIG_LOGLEVEL=warn
     steps:
       - checkout
-      - run:
-          name: Update global packages
-          command: sudo npm install -g npm@5 greenkeeper-lockfile@1
-      - run:
-          name: Maybe update dependencies lockfile
-          command: greenkeeper-lockfile-update
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install dependencies
           command: npm install
-      - run:
-          name: Maybe upload dependencies lockfile
-          command: greenkeeper-lockfile-upload
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![](enigma.png)
 
 [![CircleCI](https://circleci.com/gh/qlik-oss/enigma.js.svg?style=shield)](https://circleci.com/gh/qlik-oss/enigma.js)
-[![Greenkeeper badge](https://badges.greenkeeper.io/qlik-oss/enigma.js.svg)](https://greenkeeper.io/)
 [![Coverage Status](https://img.shields.io/coveralls/qlik-oss/enigma.js/master.svg)](https://coveralls.io/github/qlik-oss/enigma.js)
 
 enigma.js is a library that helps you communicate with Qlik QIX Engine. Examples of use may be building your own browser-based analytics tools, back-end services, or command-line scripts.


### PR DESCRIPTION
We're using dependabot now, let's get rid of these build steps that intermittently fail.