### PR TITLE
Add error code property

### DIFF
--- a/src/rpc.js
+++ b/src/rpc.js
@@ -162,7 +162,9 @@ class RPC {
   */
   send(data) {
     if (!this.socket || this.socket.readyState !== this.socket.OPEN) {
-      return this.Promise.reject(new Error('Not connected'));
+      const error = new Error('Not connected');
+      error.code = -1;
+      return this.Promise.reject(error);
     }
     if (!data.id) {
       data.id = this.createRequestId();

--- a/test/unit/rpc.spec.js
+++ b/test/unit/rpc.spec.js
@@ -50,7 +50,9 @@ describe('RPC', () => {
   });
 
   it("should reject when trying to send a message if the socket isn't open", (done) => {
-    rpc.send().then(() => {}, () => {
+    rpc.send().catch((err) => {
+      expect(err.code).to.equal(-1);
+      expect(err.message).to.equal('Not connected');
       done();
     });
   });


### PR DESCRIPTION
When a socket (and model) is closed and a user tries to use it anyway, we'll clarify the rejected request with an error code too.

Fixes #535 