### PR TITLE
fix(session): allow code and reason on session close to pass through

### DIFF
--- a/docs/api-spec.json
+++ b/docs/api-spec.json
@@ -368,7 +368,22 @@
         "close": {
           "description": "Closes the websocket and cleans up internal caches, also triggers the closed event\non all generated APIs. Note that you have to manually invoke this when you want to\nclose a session and config.suspendOnClose is true.",
           "kind": "function",
-          "params": [],
+          "params": [
+            {
+              "name": "code",
+              "description": "The reason code for closing the connection.",
+              "optional": true,
+              "defaultValue": 1000,
+              "type": "number"
+            },
+            {
+              "name": "reason",
+              "description": "The human readable string describing why the connection is closed.",
+              "optional": true,
+              "defaultValue": "\"\"",
+              "type": "string"
+            }
+          ],
           "returns": {
             "description": "Eventually resolved when the websocket has been closed.",
             "type": "Promise",

--- a/src/session.js
+++ b/src/session.js
@@ -265,9 +265,11 @@ class Session {
   * on all generated APIs. Note that you have to manually invoke this when you want to
   * close a session and config.suspendOnClose is true.
   * @emits Session#closed
+  * @param {Number} [code=1000] - The reason code for closing the connection.
+  * @param {String} [reason=""] - The human readable string describing why the connection is closed.
   * @returns {Promise<Object>} Eventually resolved when the websocket has been closed.
   */
-  close() {
+  close(code = 1000, reason = '') {
   /**
    * Handle closed state. This event is triggered when the underlying websocket is closed and
    * config.suspendOnClose is false.
@@ -275,7 +277,7 @@ class Session {
    * @type {Object}
    */
     this.globalPromise = undefined;
-    return this.rpc.close().then((evt) => this.emit('closed', evt));
+    return this.rpc.close(code, reason).then((evt) => this.emit('closed', evt));
   }
 
   /**

--- a/test/unit/session.spec.js
+++ b/test/unit/session.spec.js
@@ -275,7 +275,7 @@ describe('Session', () => {
 
   it('should close with supplied error code', () => {
     const code = 4000;
-    const reason = 'Custom application error'
+    const reason = 'Custom application error';
     const rpc = new RPCMock({
       Promise,
       url: 'http://localhost:4848',

--- a/test/unit/session.spec.js
+++ b/test/unit/session.spec.js
@@ -273,6 +273,24 @@ describe('Session', () => {
     expect(close.calledOnce).to.equal(true);
   });
 
+  it('should close with supplied error code', () => {
+    const code = 4000;
+    const reason = 'Custom application error'
+    const rpc = new RPCMock({
+      Promise,
+      url: 'http://localhost:4848',
+      createSocket: (url) => new SocketMock(url),
+    });
+    createSession(false, rpc);
+    session.getObjectApi = () => {};
+    session.open();
+    const close = sinon.spy(rpc, 'close');
+    const closePromise = session.close(code, reason);
+    expect(closePromise).to.be.an.instanceOf(Promise);
+    expect(close.calledOnce).to.equal(true);
+    expect(close).to.be.calledWith(code, reason);
+  });
+
   describe('addToPromiseChain', () => {
     it('should add value on promise', () => {
       const promise = Promise.resolve();


### PR DESCRIPTION
This allows us to run `session.close()` with a custom close code & reason. `rpc.js` already allows this; so I assume this should be allowed by `session.js` aswell. This is not being passed through.