### PR TITLE
fix(errors): better error code handling

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -658,6 +658,29 @@ const session = enigma.create({ schema, url });
 
 [Back to top](#api-documentation)
 
+## Error handling
+
+There are multiple types of errors that can occur, native WebSocket errors (See [CloseEvent](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent)),
+QIX errors and native enigma.js errors. For the enigma.js errors, you can import `enigma.js/error-codes.js` or refer to the list below. 
+All native enigma.js errors have the property `Error.enigmaError = true`. These may occur thrown or in rejected promises.
+
+| Property                              | Code     | Description |
+|---------------------------------------|----------|------------------------------------------------------------|
+| `NOT_CONNECTED`                       | `-1`     | You're trying to send data on a socket that's not created  |
+| `OBJECT_NOT_FOUND`                    | `-2`     | The object you're trying to fetch does not exist           |
+| `EXPECTED_ARRAY_OF_PATCHES`           | `-3`     | Unexpected RPC response, expected array of patches         |
+| `PATCH_HAS_NO_PARENT`                 | `-4`     | Patchee is not an object we can patch                      |
+| `ENTRY_ALREADY_DEFINED`               | `-5`     | This entry is already defined with another key             |
+| `NO_CONFIG_SUPPLIED`                  | `-6`     | You need to supply a configuration                         |
+| `PROMISE_REQUIRED`                    | `-7`     | There's no promise object available (polyfill required?)   |
+| `SCHEMA_STRUCT_TYPE_NOT_FOUND`        | `-8`     | The schema struct type you requested does not exist        |
+| `SCHEMA_MIXIN_CANT_OVERRIDE_FUNCTION` | `-9`     | Can't override this function                               |
+| `SCHEMA_MIXIN_EXTEND_NOT_ALLOWED`     | `-10`    | Extend is not allowed for this mixin                       |
+| `SESSION_SUSPENDED`                   | `-11`    | Session suspended - no interaction allowed                 |
+| `SESSION_NOT_ATTACHED`                | `-12`    | onlyIfAttached supplied, but you got SESSION_CREATED       |
+
+[Back to top](#api-documentation)
+
 ---
 
 [Back to overview](../README.md#readme)

--- a/docs/api.md
+++ b/docs/api.md
@@ -48,6 +48,7 @@ Table of contents
 - [Sense utilities API](#sense-utilities-api)
   - [Configuration](#configuration-1)
   - [`SenseUtilities.buildUrl()`](#senseutilitiesbuildurlconfig)
+- [Error handling](#error-handling)
 
 ---
 

--- a/error-codes.js
+++ b/error-codes.js
@@ -1,0 +1,14 @@
+export default {
+  NOT_CONNECTED: -1, // You're trying to send data on a socket that's not created
+  OBJECT_NOT_FOUND: -2, // The object you're trying to fetch does not exist
+  EXPECTED_ARRAY_OF_PATCHES: -3, // Unexpected RPC response, expected array of patches
+  PATCH_HAS_NO_PARENT: -4, // Patchee is not an object we can patch
+  ENTRY_ALREADY_DEFINED: -5, // This entry is already defined with another key
+  NO_CONFIG_SUPPLIED: -6, // You need to supply a configuration
+  PROMISE_REQUIRED: -7, // There's no promise object available (polyfill required?)
+  SCHEMA_STRUCT_TYPE_NOT_FOUND: -8, // The schema struct type you requested does not exist
+  SCHEMA_MIXIN_CANT_OVERRIDE_FUNCTION: -9, // Can't override this function
+  SCHEMA_MIXIN_EXTEND_NOT_ALLOWED: -10, // Extend is not allowed for this mixin
+  SESSION_SUSPENDED: -11, // Session suspended - no interaction allowed
+  SESSION_NOT_ATTACHED: -12, // onlyIfAttached supplied, but you got SESSION_CREATED
+};

--- a/src/error.js
+++ b/src/error.js
@@ -1,0 +1,6 @@
+export default function createEnigmaError(code, name) {
+  const error = new Error(name); // Name as string
+  error.code = code; // Code from 'error-codes.js'
+  error.enigmaError = true; // To be able to properly identify an enigma error
+  return error;
+}

--- a/src/error.js
+++ b/src/error.js
@@ -1,6 +1,11 @@
+/**
+ * Create an enigmaError
+ * @param {Number} code A proper error code from ../error-codes.js
+ * @param {String} name A message/name of the enigmaError.
+ */
 export default function createEnigmaError(code, name) {
-  const error = new Error(name); // Name as string
-  error.code = code; // Code from 'error-codes.js'
+  const error = new Error(name);
+  error.code = code;
   error.enigmaError = true; // To be able to properly identify an enigma error
   return error;
 }

--- a/src/interceptors/api-response-interceptor.js
+++ b/src/interceptors/api-response-interceptor.js
@@ -1,3 +1,6 @@
+import createEnigmaError from '../error';
+import errorCodes from '../../error-codes';
+
 /**
 * Response interceptor for generating APIs. Handles the quirks of engine not
 * returning an error when an object is missing.
@@ -17,7 +20,8 @@ export default function apiResponseInterceptor(session, request, response) {
     });
   }
   if (response.qHandle === null && response.qType === null) {
-    return session.config.Promise.reject(new Error('Object not found'));
+    const error = createEnigmaError(errorCodes.OBJECT_NOT_FOUND, 'Object not found');
+    return session.config.Promise.reject(error);
   }
   return response;
 }

--- a/src/interceptors/delta-response-interceptor.js
+++ b/src/interceptors/delta-response-interceptor.js
@@ -1,6 +1,9 @@
 import JSONPatch from '../json-patch';
 import KeyValueCache from '../key-value-cache';
 
+import createEnigmaError from '../error';
+import errorCodes from '../../error-codes';
+
 const sessions = {};
 
 /**
@@ -76,7 +79,7 @@ export default function deltaResponseInterceptor(session, request, response) {
     // when delta is on the response data is expected to be an array of patches:
     Object.keys(result).forEach((key) => {
       if (!Array.isArray(result[key])) {
-        throw new Error('Unexpected RPC response, expected array of patches');
+        throw createEnigmaError(errorCodes.EXPECTED_ARRAY_OF_PATCHES, 'Unexpected RPC response, expected array of patches');
       }
       result[key] = patchValue(session, request.handle, `${request.method}-${key}`, result[key]);
     });

--- a/src/json-patch.js
+++ b/src/json-patch.js
@@ -1,5 +1,8 @@
 import originalExtend from 'extend';
 
+import createEnigmaError from './error';
+import errorCodes from '../error-codes';
+
 const extend = originalExtend.bind(null, true);
 const JSONPatch = {};
 const { isArray } = Array;
@@ -290,7 +293,7 @@ JSONPatch.apply = function apply(original, patches) {
         emptyObject(target);
         extend(target, patch.value);
       } else if (!parent) {
-        throw new Error('Patchee is not an object we can patch');
+        throw createEnigmaError(errorCodes.PATCH_HAS_NO_PARENT, 'Patchee is not an object we can patch');
       } else {
         // simple value
         parent[key] = patch.value;

--- a/src/key-value-cache.js
+++ b/src/key-value-cache.js
@@ -1,3 +1,6 @@
+import createEnigmaError from './error';
+import errorCodes from '../error-codes';
+
 /**
 * Key-value cache
 * @private
@@ -17,7 +20,7 @@ class KeyValueCache {
   add(key, entry) {
     key += '';
     if (typeof this.entries[key] !== 'undefined') {
-      throw new Error(`Entry already defined with key ${key}`);
+      throw createEnigmaError(errorCodes.ENTRY_ALREADY_DEFINED, `Entry already defined with key ${key}`);
     }
     this.entries[key] = entry;
   }

--- a/src/qix.js
+++ b/src/qix.js
@@ -5,6 +5,9 @@ import SuspendResume from './suspend-resume';
 import Intercept from './intercept';
 import ApiCache from './api-cache';
 
+import createEnigmaError from './error';
+import errorCodes from '../error-codes';
+
 /**
  * The enigma.js configuration object.
  * @interface Configuration
@@ -133,12 +136,12 @@ class Qix {
   */
   static configureDefaults(config) {
     if (!config) {
-      throw new Error('You need to supply a configuration.');
+      throw createEnigmaError(errorCodes.NO_CONFIG_SUPPLIED, 'You need to supply a configuration.');
     }
 
     // eslint-disable-next-line no-restricted-globals
     if (!config.Promise && typeof Promise === 'undefined') {
-      throw new Error('Your environment has no Promise implementation. You must provide a Promise implementation in the config.');
+      throw createEnigmaError(errorCodes.PROMISE_REQUIRED, 'Your environment has no Promise implementation. You must provide a Promise implementation in the config.');
     }
 
     if (typeof config.createSocket !== 'function' && typeof WebSocket === 'function') {

--- a/src/rpc.js
+++ b/src/rpc.js
@@ -1,6 +1,9 @@
 import Events from './event-emitter';
 import RPCResolver from './rpc-resolver';
 
+import createEnigmaError from './error';
+import errorCodes from '../error-codes';
+
 /**
 * This class handles remote procedure calls on a web socket.
 * @private
@@ -164,8 +167,7 @@ class RPC {
   */
   send(data) {
     if (!this.socket || this.socket.readyState !== this.socket.OPEN) {
-      const error = new Error('Not connected');
-      error.code = -1;
+      const error = createEnigmaError(errorCodes.NOT_CONNECTED, 'Not connected');
       return this.Promise.reject(error);
     }
     if (!data.id) {

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,6 +1,9 @@
 import KeyValueCache from './key-value-cache';
 import Events from './event-emitter';
 
+import createEnigmaError from './error';
+import errorCodes from '../error-codes';
+
 const { hasOwnProperty } = Object.prototype;
 
 /**
@@ -84,7 +87,7 @@ class Schema {
       return entry;
     }
     if (!this.schema.structs[type]) {
-      throw new Error(`${type} not found`);
+      throw createEnigmaError(errorCodes.SCHEMA_STRUCT_TYPE_NOT_FOUND, `${type} not found`);
     }
     const factory = this.generateApi(type, this.schema.structs[type]);
     this.types.add(type, factory);
@@ -191,13 +194,13 @@ class Schema {
               return override[key].apply(this, [baseFn.bind(this), ...args]);
             };
           } else {
-            throw new Error(`No function to override. Type: ${type} function: ${key}`);
+            throw createEnigmaError(errorCodes.SCHEMA_MIXIN_CANT_OVERRIDE_FUNCTION, `No function to override. Type: ${type} function: ${key}`);
           }
         });
         Object.keys(extend).forEach((key) => {
           // handle overrides
           if (typeof api[key] === 'function' && typeof extend[key] === 'function') {
-            throw new Error(`Extend is not allowed for this mixin. Type: ${type} function: ${key}`);
+            throw createEnigmaError(errorCodes.SCHEMA_MIXIN_EXTEND_NOT_ALLOWED, `Extend is not allowed for this mixin. Type: ${type} function: ${key}`);
           } else {
             api[key] = extend[key];
           }

--- a/src/session.js
+++ b/src/session.js
@@ -1,5 +1,8 @@
 import EventEmitter from './event-emitter';
 
+import createEnigmaError from './error';
+import errorCodes from '../error-codes';
+
 const RPC_CLOSE_NORMAL = 1000;
 const RPC_CLOSE_MANUAL_SUSPEND = 4000;
 
@@ -206,7 +209,7 @@ class Session {
   */
   send(request) {
     if (this.suspendResume.isSuspended) {
-      return this.Promise.reject(new Error('Session suspended'));
+      return this.Promise.reject(createEnigmaError(errorCodes.SESSION_SUSPENDED, 'Session suspended'));
     }
     request.id = this.rpc.createRequestId();
     const promise = this.intercept.executeRequests(this, this.Promise.resolve(request))

--- a/src/suspend-resume.js
+++ b/src/suspend-resume.js
@@ -1,3 +1,6 @@
+import createEnigmaError from './error';
+import errorCodes from '../error-codes';
+
 const ON_ATTACHED_TIMEOUT_MS = 5000;
 const RPC_CLOSE_MANUAL_SUSPEND = 4000;
 
@@ -30,7 +33,7 @@ class SuspendResume {
   restoreRpcConnection(onlyIfAttached) {
     return this.reopen(ON_ATTACHED_TIMEOUT_MS).then((sessionState) => {
       if (sessionState === 'SESSION_CREATED' && onlyIfAttached) {
-        return this.Promise.reject(new Error('Not attached'));
+        return this.Promise.reject(createEnigmaError(errorCodes.SESSION_NOT_ATTACHED, 'Not attached'));
       }
       return this.Promise.resolve();
     });

--- a/test/unit/error.spec.js
+++ b/test/unit/error.spec.js
@@ -1,0 +1,12 @@
+import createEnigmaError from '../../src/error';
+
+describe('createEnigmaError', () => {
+  it('should create a proper enigma error', () => {
+    const error = createEnigmaError(-42, 'My custom error');
+
+    expect(error instanceof Error).to.equal(true);
+    expect(error.code).to.equal(-42);
+    expect(error.message).to.equal('My custom error');
+    expect(error.enigmaError).to.equal(true);
+  });
+});


### PR DESCRIPTION
Improves the error code handling in other projects using enigma.js by specifing a table to lookup when looking for error codes. I've placed the `error-codes.js` in the root to allow it to be imported as `import enigmaErrorCodes from 'enigma.js/error-codes';`

I've searched through the source code and replaced all existing `new Error(` with this new `createEnigmaError` function to streamline this. The only place I've not modified is `error-response-interceptor.js` because, naturally, it sets the error code from the QIX error that it has recieved on the websocket.

`createEnigmaError` does not break existing errors because it only attaches two new things to the existing error with the existing error message:
1. An error code that can be mapped from 'error-codes.js' (Error.code = -5)
2. enigmaError boolean to identify an enigmaError (Error.enigmaError = true) 

## These are the error codes I've specified
```js
export default {
  NOT_CONNECTED: -1, // You're trying to send data on a socket that's not created
  OBJECT_NOT_FOUND: -2, // The object you're trying to fetch does not exist
  EXPECTED_ARRAY_OF_PATCHES: -3, // Unexpected RPC response, expected array of patches
  PATCH_HAS_NO_PARENT: -4, // Patchee is not an object we can patch
  ENTRY_ALREADY_DEFINED: -5, // This entry is already defined with another key
  NO_CONFIG_SUPPLIED: -6, // You need to supply a configuration
  PROMISE_REQUIRED: -7, // There's no promise object available (polyfill required?)
  SCHEMA_STRUCT_TYPE_NOT_FOUND: -8, // The schema struct type you requested does not exist
  SCHEMA_MIXIN_CANT_OVERRIDE_FUNCTION: -9, // Can't override this function
  SCHEMA_MIXIN_EXTEND_NOT_ALLOWED: -10, // Extend is not allowed for this mixin
  SESSION_SUSPENDED: -11, // Session suspended - no interaction allowed
  SESSION_NOT_ATTACHED: -12, // onlyIfAttached supplied, but you got SESSION_CREATED
};
```