### PR TITLE
chore: dont generate source maps for error-codes

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -66,6 +66,7 @@ const errorCodes = createConfig({
   output: {
     file: 'error-codes.js',
     name: 'error-codes',
+    sourcemap: false,
   },
 });
 


### PR DESCRIPTION
When the package was being bundled, the bundler displays a warning that it can not find the source maps for `error-codes.js`. The reason is we are not including the map files since they arent needed for that particular file, so we can just skip generating the source maps altogether.

```
WARNING in ../node_modules/enigma.js/error-codes.js
Module Warning (from ../node_modules/source-map-loader/index.js):
(Emitted value instead of an instance of Error) Cannot find SourceMap 'error-codes.js.map': Error: Can't resolve './error-codes.js.map' in '~/PROJECT/node_modules/enigma.js'
```