### PR TITLE
feat: send code and reason through suspend chain

### DIFF
--- a/docs/api-spec.json
+++ b/docs/api-spec.json
@@ -549,7 +549,22 @@
         "suspend": {
           "description": "Suspends the enigma.js session by closing the websocket and rejecting all method calls\nuntil is has been resumed again.",
           "kind": "function",
-          "params": [],
+          "params": [
+            {
+              "name": "code",
+              "description": "The reason code for suspending the connection.",
+              "optional": true,
+              "defaultValue": 4000,
+              "type": "number"
+            },
+            {
+              "name": "reason",
+              "description": "The human readable string describing why the connection is suspended.",
+              "optional": true,
+              "defaultValue": "\"\"",
+              "type": "string"
+            }
+          ],
           "returns": {
             "description": "Eventually resolved when the websocket has been closed.",
             "type": "Promise",

--- a/docs/api-spec.json
+++ b/docs/api-spec.json
@@ -559,7 +559,7 @@
             },
             {
               "name": "reason",
-              "description": "The human readable string describing why the connection is suspended.",
+              "description": "The human readable string describing\nwhy the connection is suspended.",
               "optional": true,
               "defaultValue": "\"\"",
               "type": "string"

--- a/docs/api.md
+++ b/docs/api.md
@@ -256,7 +256,7 @@ session.close().then(() => console.log('Session was properly closed'));
 
 [Back to top](#api-documentation)
 
-### `session.suspend()`
+### `session.suspend([code=4000, reason=''])`
 
 Returns a promise.
 

--- a/src/session.js
+++ b/src/session.js
@@ -231,11 +231,14 @@ class Session {
   * Suspends the enigma.js session by closing the websocket and rejecting all method calls
   * until is has been resumed again.
   * @emits Session#suspended
+  * @param {Number} [code=4000] - The reason code for suspending the connection.
+  * @param {String} [reason=""] - The human readable string describing
+  * why the connection is suspended.
   * @returns {Promise<Object>} Eventually resolved when the websocket has been closed.
   */
-  suspend() {
-    return this.suspendResume.suspend()
-      .then(() => this.emit('suspended', { initiator: 'manual' }));
+  suspend(code = 4000, reason = '') {
+    return this.suspendResume.suspend(code, reason)
+      .then(() => this.emit('suspended', { initiator: 'manual', code, reason }));
   }
 
   /**

--- a/src/session.js
+++ b/src/session.js
@@ -83,10 +83,11 @@ class Session {
       return;
     }
     if (this.config.suspendOnClose) {
-      this.suspendResume.suspend().then(() => this.emit('suspended', {
+      const { code, reason } = evt;
+      this.suspendResume.suspend(code, reason).then(() => this.emit('suspended', {
         initiator: 'network',
-        code: evt.code,
-        reason: evt.reason,
+        code,
+        reason,
       }));
     } else {
       this.emit('closed', evt);

--- a/src/session.js
+++ b/src/session.js
@@ -83,7 +83,11 @@ class Session {
       return;
     }
     if (this.config.suspendOnClose) {
-      this.suspendResume.suspend().then(() => this.emit('suspended', { initiator: 'network' }));
+      this.suspendResume.suspend().then(() => this.emit('suspended', {
+        initiator: 'network',
+        code: evt.code,
+        reason: evt.reason,
+      }));
     } else {
       this.emit('closed', evt);
     }

--- a/src/suspend-resume.js
+++ b/src/suspend-resume.js
@@ -137,10 +137,12 @@ class SuspendResume {
   /**
   * Set the instance as suspended.
   * @private
+  * @param {Number} [code=4000] - The reason code for closing the connection.
+  * @param {String} [reason=""] - The human readable string describing why the connection is closed.
   */
-  suspend() {
+  suspend(code = 4000, reason = '') {
     this.isSuspended = true;
-    return this.rpc.close(RPC_CLOSE_MANUAL_SUSPEND);
+    return this.rpc.close(code, reason);
   }
 
   /**

--- a/src/suspend-resume.js
+++ b/src/suspend-resume.js
@@ -140,7 +140,7 @@ class SuspendResume {
   * @param {Number} [code=4000] - The reason code for closing the connection.
   * @param {String} [reason=""] - The human readable string describing why the connection is closed.
   */
-  suspend(code = 4000, reason = '') {
+  suspend(code = RPC_CLOSE_MANUAL_SUSPEND, reason = '') {
     this.isSuspended = true;
     return this.rpc.close(code, reason);
   }

--- a/test/unit/session.spec.js
+++ b/test/unit/session.spec.js
@@ -291,6 +291,24 @@ describe('Session', () => {
     expect(close).to.be.calledWith(code, reason);
   });
 
+  it('should suspend with supplied error code', () => {
+    const code = 4000;
+    const reason = 'Custom application error';
+    const rpc = new RPCMock({
+      Promise,
+      url: 'http://localhost:4848',
+      createSocket: (url) => new SocketMock(url),
+    });
+    createSession(false, rpc);
+    session.getObjectApi = () => {};
+    session.open();
+    const suspend = sinon.spy(session.suspendResume, 'suspend');
+    const suspendPromise = session.suspend(code, reason);
+    expect(suspendPromise).to.be.an.instanceOf(Promise);
+    expect(suspend.calledOnce).to.equal(true);
+    expect(suspend).to.be.calledWith(code, reason);
+  });
+
   describe('addToPromiseChain', () => {
     it('should add value on promise', () => {
       const promise = Promise.resolve();


### PR DESCRIPTION
<!-- Please include a summary of your changes in this pull request. -->

Added a session to the window to test this, and then called suspend manually. First case is where I pass the code and reason through, and the second one is the default one. The code was `4000` by default previously so maintaining that.

![image](https://user-images.githubusercontent.com/5672257/68670865-3a2f7c80-054e-11ea-899d-0c890f6419f9.png)
