### PR TITLE
fix(session): no echo code on suspend in rpcClosed

### DIFF
--- a/src/session.js
+++ b/src/session.js
@@ -84,7 +84,7 @@ class Session {
     }
     if (this.config.suspendOnClose) {
       const { code, reason } = evt;
-      this.suspendResume.suspend(code, reason).then(() => this.emit('suspended', {
+      this.suspendResume.suspend().then(() => this.emit('suspended', {
         initiator: 'network',
         code,
         reason,


### PR DESCRIPTION
Echoing close code from `onRpcClosed` to `suspend` will cause the suspend to fail if `onRpcClosed` was called with a code that's not `1000` or `3000-5999` as per the WebSocket Close Code Spec.

If we get an abnormal close on the socket, i.e. close `1006`, this will in turn call `onRpcClosed`. If the session config has `suspendOnClose = true` - this code will trigger `this.rpc.close(code, reason)` with `1006` code. This throws an error in the browser, as it's only the browser that is allowed to throw errors such as 1006, which in turn makes the `suspend` event never being fired. 

The close code sent to suspendResume is irrelevant because the socket is already closed.

<!-- Please include a summary of your changes in this pull request. -->
