### PR TITLE
fix: response parameters for StoreTempSelectionState

### DIFF
--- a/src/interceptors/out-param-response-interceptor.js
+++ b/src/interceptors/out-param-response-interceptor.js
@@ -14,9 +14,10 @@ export default function outParamResponseInterceptor(session, request, response) 
     // this method returns multiple out params that we need
     // to normalize before processing the response further:
     response[RETURN_KEY].qGenericId = response.qSessionAppId || response[RETURN_KEY].qGenericId;
-  } else if (request.method === 'GetInteract') {
+  } else if (request.method === 'GetInteract' || request.method === 'StoreTempSelectionState') {
     // this method returns a qReturn value when it should only return
-    // meta.outKey:
+    // meta.outKey: GetInteract
+    // qId: StoreTempSelectionState
     delete response[RETURN_KEY];
   }
 


### PR DESCRIPTION
StoreTempSelectionState only returns a boolean when called because in includes the qReturn key. It should return the qId instead.
Engine cannot update this because it will be a breaking API change