### PR TITLE
fix: dont emit message if resolver undefined

### DIFF
--- a/src/rpc.js
+++ b/src/rpc.js
@@ -115,7 +115,7 @@ class RPC {
     const data = JSON.parse(event.data);
     const resolver = this.resolvers[data.id] || {};
     this.emit('traffic', 'received', data, resolver.handle);
-    if (typeof data.id !== 'undefined') {
+    if (typeof data.id !== 'undefined' && this.resolvers[data.id]) {
       this.emit('message', data);
       this.resolvers[data.id].resolveWith(data);
     } else {


### PR DESCRIPTION
With our implementation of Enigma we hit a snag where the resolver can be undefined. 

This fix ensures that if the resolver is undefined Enigma wont crash.


