### PR TITLE
fix: guard against empty patch array

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
   working_directory: ~/enigma.js
   # Available images https://hub.docker.com/r/circleci/node/tags/
   docker:
-    - image: circleci/node:21.5.0
+    - image: cimg/node:21.5.0
 
 jobs:
   install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ defaults: &defaults
   working_directory: ~/enigma.js
   # Available images https://hub.docker.com/r/circleci/node/tags/
   docker:
-    - image: circleci/node:17.2.0
-    
+    - image: circleci/node:21.5.0
+
 jobs:
   install:
     <<: *defaults
@@ -25,7 +25,7 @@ jobs:
           command: npm run -s lint
       - persist_to_workspace:
           root: ~/enigma.js
-          paths: 
+          paths:
             - .
   check-api-specs:
     <<: *defaults
@@ -91,7 +91,7 @@ jobs:
           name: Run API Compliance
           command: >
             VER=v$(cat version.txt)
-                        
+
             docker run --volumes-from specs
             -e SPEC_PATHS="0f0b4c98-db9c-46c7-8958-2a98bd15a946@/specs/api-spec.json"
             -e COMMIT_SHA="$CIRCLE_SHA1"
@@ -106,7 +106,7 @@ workflows:
    jobs:
      - install
      - check-api-specs:
-         requires: 
+         requires:
            - install
      - build:
          requires:
@@ -115,4 +115,3 @@ workflows:
          context: api-compliance
          requires:
            - check-api-specs
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "rollup-plugin-node-resolve": "5.2.0",
         "rollup-plugin-terser": "7.0.2",
         "scriptappy-from-jsdoc": "0.7.0",
-        "ws": "8.16.0"
+        "ws": "8.13.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -23282,9 +23282,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -41675,9 +41675,9 @@
       }
     },
     "ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-terser": "7.0.2",
     "scriptappy-from-jsdoc": "0.7.0",
-    "ws": "8.16.0"
+    "ws": "8.13.0"
   }
 }

--- a/src/interceptors/delta-response-interceptor.js
+++ b/src/interceptors/delta-response-interceptor.js
@@ -50,7 +50,7 @@ const patchValue = (session, handle, cacheId, patches) => {
   const cache = getHandleCache(session, handle);
   let entry = cache.get(cacheId);
   if (typeof entry === 'undefined') {
-    entry = Array.isArray(patches[0].value) ? [] : {};
+    entry = patches.length && Array.isArray(patches[0].value) ? [] : {};
   }
   if (patches.length) {
     if (patches[0].path === '/' && typeof patches[0].value !== 'object') {

--- a/src/interceptors/delta-response-interceptor.js
+++ b/src/interceptors/delta-response-interceptor.js
@@ -50,7 +50,7 @@ const patchValue = (session, handle, cacheId, patches) => {
   const cache = getHandleCache(session, handle);
   let entry = cache.get(cacheId);
   if (typeof entry === 'undefined') {
-    entry = Array.isArray(patches[0].value) ? [] : {};
+    entry = patches[0] && Array.isArray(patches[0].value) ? [] : {};
   }
   if (patches.length) {
     if (patches[0].path === '/' && typeof patches[0].value !== 'object') {

--- a/src/interceptors/delta-response-interceptor.js
+++ b/src/interceptors/delta-response-interceptor.js
@@ -50,7 +50,7 @@ const patchValue = (session, handle, cacheId, patches) => {
   const cache = getHandleCache(session, handle);
   let entry = cache.get(cacheId);
   if (typeof entry === 'undefined') {
-    entry = patches.length && Array.isArray(patches[0].value) ? [] : {};
+    entry = Array.isArray(patches[0].value) ? [] : {};
   }
   if (patches.length) {
     if (patches[0].path === '/' && typeof patches[0].value !== 'object') {


### PR DESCRIPTION
<!-- Please include a summary of your changes in this pull request. -->
Empty array reponses from engine causes a js exception in the delta patching, there are not apparent side effects as the delta is zero, but good to get rid of the error.