### PR TITLE
doc: extract correct header from csrf-response

### DIFF
--- a/examples/authentication/sense-using-jwt/jwt.js
+++ b/examples/authentication/sense-using-jwt/jwt.js
@@ -13,7 +13,7 @@ const getCsrfToken = async (host, auth) => {
         Authorization: `Bearer ${auth}`,
       },
     });
-    return res.headers.get('QLIK_CSRF_TOKEN');
+    return res.headers.get('qlik-csrf-token');
   } catch (err) {
     console.log('Failed to fetch csrf-token', err);
   }


### PR DESCRIPTION
Fix the JWT-example so that it uses the correct header-field to retrieve the CSRF-token.