### PR TITLE
fix(security): upgrade vulnerable axios, jsonwebtoken and ws in examples

### DIFF
--- a/examples/complete/car-models/package.json
+++ b/examples/complete/car-models/package.json
@@ -25,7 +25,6 @@
     "json-loader": "^0.5.7",
     "raw-loader": "^0.5.1",
     "webpack": "^3.8.1",
-    "webpack-dev-server": "^2.9.3",
-    "ws": "^3.2.0"
+    "webpack-dev-server": "^2.9.3"
   }
 }

--- a/examples/package.json
+++ b/examples/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "description": "enigma.js runnable examples dependencies",
   "dependencies": {
-    "axios": "^0.19.2",
+    "axios": "^1.19.0",
     "enigma.js": "^2.0.0",
-    "jsonwebtoken": "^7.4.2",
-    "ws": "^3.1.0"
+    "jsonwebtoken": "^9.0.3",
+    "ws": "^8.21.2"
   }
 }


### PR DESCRIPTION
## Summary

Dependabot lists 60 open alerts on this repo (1 critical, 29 high). Almost all of them trace back to three severely outdated packages pinned in the checked-in example apps (`examples/package.json` and `examples/complete/car-models/package.json`):

| Package | Was | Now | Notable advisories |
|---|---|---|---|
| `axios` | `^0.19.2` | `^1.19.0` | SSRF ([GHSA-jr5f-v2jv-69x6](https://github.com/advisories/GHSA-jr5f-v2jv-69x6)), prototype pollution → credential theft/response tampering ([GHSA-3g43-6gmg-66jw](https://github.com/advisories/GHSA-3g43-6gmg-66jw), [GHSA-pf86-5x62-jrwf](https://github.com/advisories/GHSA-pf86-5x62-jrwf)), proxy credential leaks, ReDoS |
| `jsonwebtoken` | `^7.4.2` | `^9.0.3` | insecure/legacy key handling, algorithm confusion, signature validation bypass ([GHSA-8cf7-32gw-wr33](https://github.com/advisories/GHSA-8cf7-32gw-wr33), [GHSA-qwph-4952-7xr6](https://github.com/advisories/GHSA-qwph-4952-7xr6)) |
| `ws` | `^3.1.0` / `^3.2.0` | `^8.21.2` (examples) / removed (car-models) | memory-exhaustion & header-count DoS ([GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p), [GHSA-3h5v-q93c-6h6q](https://github.com/advisories/GHSA-3h5v-q93c-6h6q)) |

The `car-models` example's `ws` devDependency is removed rather than bumped, since it's never actually imported there — the browser bundle uses the native `WebSocket` global (`examples/complete/car-models/src/app.js`).

**Scope note:** the published `enigma.js` library itself ships zero runtime dependencies (its own `devDependencies` `ws@8.21.1` is already on a patched version), so none of this affects downstream consumers of the npm package — it only cleans up the example apps included in this repo.

Verified the affected call sites (`axios.post(url, data, config)`, `jwt.sign(payload, key, { algorithm })`, `new WebSocket(url, { headers })`) are unchanged across these major version bumps — no code changes needed beyond the manifest bumps.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run test:unit` — 149/149 tests pass
- [x] Manually reviewed every example file importing `axios`/`jsonwebtoken`/`ws` for API compatibility with the new major versions